### PR TITLE
[oa_sections] Gets this feature out of its overridden state.

### DIFF
--- a/modules/oa_sections/oa_sections.features.field_base.inc
+++ b/modules/oa_sections/oa_sections.features.field_base.inc
@@ -119,11 +119,11 @@ function oa_sections_field_default_field_bases() {
     'entity_types' => array(),
     'field_name' => 'field_oa_user_ref',
     'foreign keys' => array(
-      'node' => array(
+      'users' => array(
         'columns' => array(
-          'target_id' => 'nid',
+          'target_id' => 'uid',
         ),
-        'table' => 'node',
+        'table' => 'users',
       ),
     ),
     'indexes' => array(

--- a/modules/oa_sections/oa_sections.features.inc
+++ b/modules/oa_sections/oa_sections.features.inc
@@ -7,16 +7,13 @@
 /**
  * Implements hook_ctools_plugin_api().
  */
-function oa_sections_ctools_plugin_api() {
-  list($module, $api) = func_get_args();
+function oa_sections_ctools_plugin_api($module = NULL, $api = NULL) {
   if ($module == "field_group" && $api == "field_group") {
     return array("version" => "1");
   }
-  list($module, $api) = func_get_args();
   if ($module == "page_manager" && $api == "pages_default") {
     return array("version" => "1");
   }
-  list($module, $api) = func_get_args();
   if ($module == "strongarm" && $api == "strongarm") {
     return array("version" => "1");
   }
@@ -25,7 +22,7 @@ function oa_sections_ctools_plugin_api() {
 /**
  * Implements hook_views_api().
  */
-function oa_sections_views_api() {
+function oa_sections_views_api($module = NULL, $api = NULL) {
   return array("api" => "3.0");
 }
 

--- a/modules/oa_sections/oa_sections.info
+++ b/modules/oa_sections/oa_sections.info
@@ -11,6 +11,7 @@ dependencies[] = oa_core
 dependencies[] = oa_teams
 dependencies[] = og
 dependencies[] = options
+dependencies[] = panopoly_pages
 dependencies[] = reference_option_limit
 dependencies[] = strongarm
 dependencies[] = text


### PR DESCRIPTION
This was just a `drush fu` on this feature from a clean install. I'm not really sure why `panopoly_pages` was added as a dependency. Does this seem right?
