### PR TITLE
Add 'oa_access' module for generic Group/Team-based permissions

### DIFF
--- a/modules/oa_access/oa_access.admin.inc
+++ b/modules/oa_access/oa_access.admin.inc
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @file
+ * Administration pages and forms for the Open Atrium Access module.
+ */
+
+/**
+ * Form constructor for the Group permissions form.
+ *
+ * Internally it uses _oa_access_permissions_form() to build the
+ * actual form and handle submit.
+ *
+ * @see _oa_access_permissions_form()
+ * @see _oa_access_permissions_form_submit()
+ */
+function oa_access_group_permissions_form($form, &$form_state) {
+  $message = '<p>' . t('Please select which Groups have which permissions.') . '</p>';
+
+  $form['message'] = array(
+    '#markup' => $message
+  );
+
+  $groups = oa_core_get_all_groups();
+  return _oa_access_permissions_form($form, $form_state, OA_ACCESS_GROUP_PERMISSION, t('Groups'), $groups);
+}
+
+/**
+ * Form constructor for the Team permissions form.
+ *
+ * Internally it uses _oa_access_permissions_form() to build the
+ * actual form and handle submit.
+ *
+ * @see _oa_access_permissions_form()
+ * @see _oa_access_permissions_form_submit()
+ */
+function oa_access_team_permissions_form($form, &$form_state, $group_type, $gid) {
+  $message = '<p>' . t('Please select which Teams have which permissions.') . '</p>';
+  if (user_permission('administer oa_access permissions')) {
+    $message .= '<p>' . t('You can also <a href="!url">use Groups</a> to control who has which permission.', array('!url' => url('admin/openatrium/oa_access'))) . '</p>';
+  }
+
+  $form['message'] = array(
+    '#markup' => $message
+  );
+
+  $groups = oa_teams_get_teams_for_space($gid);
+  return _oa_access_permissions_form($form, $form_state, OA_ACCESS_TEAM_PERMISSION, t('Teams'), $groups);
+}
+
+/**
+ * Internal form constructor for both the Group and Team permissions forms.
+ *
+ * @param int $type
+ *   A permission type flag for which permissions should be included.
+ * @param string $groups_label
+ *   The label to use for the groups field.
+ * @param array $groups
+ *   An array of nodes representing each of the available groups.
+ *
+ * @see _oa_access_permissions_form_submit()
+ * @see oa_access_group_permissions_form()
+ * @see oa_access_team_permissions_form()
+ *
+ * @ingroup forms
+ */
+function _oa_access_permissions_form($form, &$form_state, $type, $group_label, $groups) {
+  $permissions = array();
+  foreach (oa_access_get_permissions() as $name => $perm) {
+    if ($perm['type'] & $type) {
+      $permissions[$perm['module']][$name] = $perm;
+    }
+  }
+
+  $group_options = array();
+  foreach ($groups as $group) {
+    $group_options[$group->nid] = $group->title;
+  }
+
+  // Load the current values from the database and put into the format needed
+  // by #default_value for a multiple select.
+  $values = array();
+  $group_permissions = oa_access_get_group_permissions(array_keys($group_options));
+  foreach ($group_permissions as $gid => $modules) {
+    foreach ($modules as $module => $perms) {
+      foreach ($perms as $perm) {
+        $values[$perm][$gid] = $gid;
+      }
+    }
+  }
+
+  $form['groups'] = array(
+    '#type' => 'value',
+    '#value' => $groups,
+  );
+
+  // Get a list of all the modules implementing a hook_permission() and sort by
+  // display name.
+  $module_info = system_get_info('module');
+  $modules = array();
+  foreach (array_keys($permissions) as $module) {
+    $modules[$module] = $module_info[$module]['name'];
+  }
+  asort($modules);
+
+  // Use the same 'Compact mode' setting as the normal user permissions page.
+  $hide_descriptions = system_admin_compact_mode();
+
+  // Put each of the permissions on the form with a list of Groups that can
+  // do them. This will be themed into a table.
+  $form['permissions'] = array(
+    '#tree' => TRUE,
+    '#theme' => 'oa_access_permissions_form',
+  );
+  foreach ($modules as $module => $module_name) {
+    $form['permissions'][$module] = array(
+      '#type' => 'item',
+      '#markup' => $module_name,
+      '#id' => $module,
+    );
+    foreach ($permissions[$module] as $name => $perm) {
+      $form['permissions'][$module][$name]['name'] = array(
+        '#type' => 'item',
+        '#title' => t('Permission'),
+        '#markup' => $perm['title'],
+        '#description' => !empty($perm['description']) && !$hide_descriptions ? $perm['description'] : '',
+      );
+
+      $form['permissions'][$module][$name]['groups'] = array(
+        '#type' => 'select',
+        '#title' => $group_label,
+        '#multiple' => TRUE,
+        '#options' => $group_options,
+        '#default_value' => isset($values[$name]) ? $values[$name] : array(),
+        '#attributes' => array(
+          'class' => array('chosen-widget'),
+        ),
+      );
+    }
+  }
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Save permissions'),
+  );
+
+  $form['#submit'][] = '_oa_access_permissions_form_submit';
+  return $form;
+}
+
+/**
+ * Form submission handler for both the Group and Team permissions forms.
+ *
+ * @see _oa_access_permissions_form()
+ * @see oa_access_group_permissions_form()
+ * @see oa_access_team_permissions_form()
+ */
+function _oa_access_permissions_form_submit($form, &$form_state) {
+  // Re-organize the form values into the format expected by
+  // oa_access_set_group_permissions().
+  $group_permissions = array();
+  foreach ($form_state['values']['groups'] as $group) {
+    $group_permissions[$group->nid] = array();
+  }
+  foreach ($form_state['values']['permissions'] as $module => $permissions) {
+    foreach ($permissions as $name => $perm) {
+      foreach ($perm['groups'] as $nid) {
+        $group_permissions[$nid][$module][] = $name;
+      }
+    }
+  }
+
+  // Actually save to the database.
+  oa_access_set_group_permissions($group_permissions);
+
+  drupal_set_message(t('The changes have been saved.'));
+}

--- a/modules/oa_access/oa_access.admin.inc
+++ b/modules/oa_access/oa_access.admin.inc
@@ -36,7 +36,7 @@ function oa_access_group_permissions_form($form, &$form_state) {
 function oa_access_team_permissions_form($form, &$form_state, $group_type, $gid) {
   $message = '<p>' . t('Please select which Teams have which permissions.') . '</p>';
   if (user_permission('administer oa_access permissions')) {
-    $message .= '<p>' . t('You can also <a href="!url">use Groups</a> to control who has which permission.', array('!url' => url('admin/openatrium/oa_access'))) . '</p>';
+    $message .= '<p>' . t('You can also <a href="!url">use Groups</a> to control who has which permission.', array('!url' => url('groups/oa_access'))) . '</p>';
   }
 
   $form['message'] = array(

--- a/modules/oa_access/oa_access.api.php
+++ b/modules/oa_access/oa_access.api.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @file
+ * Contains documentation about the Open Atrium Access module's hooks.
+ */
+
+/**
+ * @defgroup oa_access Open Atrium Access
+ * @{
+ * Hooks from the Open Atrium Access module.
+ */
+
+/**
+ * Define an Open Atrium permission that can be assigned to a Group or Team.
+ *
+ * This hook can supply permissions that the module defines, so that they
+ * can be selected on the admin page and used to grant or restrict access to
+ * certain actions the module performs.
+ *
+ * @return array
+ *   An associative array whose keys are permission names and values are
+ *   associative arrays containing the following keys:
+ *   - title: Human readable name of the permission.
+ *   - description: (Optional) Human readable description of the permission.
+ *   - type: (Optional) Flag specifying if it can be assigned to Groups or
+ *     Teams or both. By default, it allows both.
+ *     - OA_ACCESS_DEFAULT_PERMISSION: (default) Allows this permission on both
+ *       Groups on Teams.
+ *     - OA_ACCESS_GROUP_PERMISSION: Only allowed on Groups.
+ *     - OA_ACCESS_TEAM_PERMISSION: Only allowed on Teams.
+ *     The flags can be combined if you'd like to be explicit, for exampl:
+ *     @code
+ *       'type' => OA_ACCESS_GROUP_PERMISSION | OA_ACCESS_TEAM_PERMISSION,
+ *     @endcode
+ *
+ * @see hook_oa_access_permission_alter()
+ */
+function hook_oa_access_permission() {
+  return array(
+    'do something awesome' => array(
+      'title' => t('Do something awesome'),
+      'description' => t('Be careful who give this permission to, because soon everyone might want it!'),
+    ),
+  );
+}
+
+/**
+ * Alter the Open Atrium permissions.
+ *
+ * @param array $perms
+ *   Associative array keyed with the permission name containing associative
+ *   arrays with the following keys:
+ *   - title: Human readable name of the permission.
+ *   - description: Human readable description of the permission.
+ *   - module: The machine name of the module which defines it.
+ *
+ * @see hook_oa_access_permission()
+ */
+function hook_oa_access_permission_alter(&$perms) {
+  // Give this permission a more awesome title.
+  if (isset($perms['do something awesome'])) {
+    $perms['do something awesome']['title'] = t('Do something so completely and totally AWESOME!!!!');
+  }
+}
+
+/**
+ * @}
+ */

--- a/modules/oa_access/oa_access.info
+++ b/modules/oa_access/oa_access.info
@@ -1,0 +1,9 @@
+name = Open Atrium Access
+description = Access control API based on Open Atrium Groups and Teams.
+package = Open Atrium
+core = 7.x
+
+files[] = tests/oa_access.test
+
+dependencies[] = og_ui
+dependencies[] = oa_core

--- a/modules/oa_access/oa_access.install
+++ b/modules/oa_access/oa_access.install
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @file
+ * Install hooks for the Open Atrium Access module.
+ */
+
+/**
+ * Implements hook_schema().
+ */
+function oa_access_schema() {
+  $schema = array();
+  $schema['oa_access'] = array(
+    'description' => 'Stores the permissions assigned to Groups or Teams.',
+    'fields' => array(
+      'nid' => array(
+        'description' => 'The primary identifier for a node.',
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ),
+      'permission' => array(
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'A single permission granted to the role identified by rid.',
+      ),
+      'module' => array(
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+        'description' => 'The module declaring the permission.',
+      ),
+    ),
+    'primary key' => array('nid', 'permission'),
+    'indexes' => array(
+      'nid' => array('nid'),
+      'permission' => array('permission'),
+    ),
+    'foreign keys' => array(
+      'node' => array(
+        'table' => 'node',
+        'columns' => array('nid' => 'nid'),
+      ),
+    ),
+  );
+  return $schema;
+}

--- a/modules/oa_access/oa_access.module
+++ b/modules/oa_access/oa_access.module
@@ -1,0 +1,482 @@
+<?php
+/**
+ * @file
+ * Code for the Open Atrium Access module.
+ */
+
+/**
+ * Path to the Group admin page.
+ */
+define('OA_ACCESS_GROUP_ADMIN_PATH', 'groups/oa_access');
+
+/**
+ * Path to the Team admin pages.
+ */
+define('OA_ACCESS_TEAM_ADMIN_PATH', 'group/%/%/admin/oa_access');
+
+/**
+ * Permission type -- Allows permission to be assigned to a Team.
+ */
+define('OA_ACCESS_TEAM_PERMISSION', 1);
+
+/**
+ * Permission type -- Allows permission to be assigned to a Group.
+ */
+define('OA_ACCESS_GROUP_PERMISSION', 2);
+
+/**
+ * Permission type -- Allows permission to be assigned to either Team or Group.
+ */
+define('OA_ACCESS_DEFAULT_PERMISSION', OA_ACCESS_TEAM_PERMISSION | OA_ACCESS_GROUP_PERMISSION);
+
+/**
+ * Implements hook_menu().
+ */
+function oa_access_menu() {
+  $items = array();
+  $items[OA_ACCESS_GROUP_ADMIN_PATH] = array(
+    'title' => 'Access',
+    'description' => 'Configure which Groups have which permissions.',
+    'access arguments' => array('administer oa_access permissions'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('oa_access_group_permissions_form'),
+    'file' => 'oa_access.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+  );
+  if (module_exists('oa_teams')) {
+    $items[OA_ACCESS_TEAM_ADMIN_PATH] = array(
+      'title' => 'Team access',
+      'description' => 'Configure which Teams have which permissions.',
+      'access callback' => 'og_ui_user_access_group',
+      'access arguments' => array('administer oa_access permissions', 1, 2),
+      'page callback' => 'drupal_get_form',
+      'page arguments' => array('oa_access_team_permissions_form', 1, 2),
+      'file' => 'oa_access.admin.inc',
+      'type' => MENU_NORMAL_ITEM,
+    );
+  }
+  return $items;
+}
+
+/**
+ * Implements hook_menu_alter().
+ */
+function oa_access_menu_alter(&$items) {
+  if (!isset($items['groups/list'])) {
+    $items['groups/list'] = array(
+      'title' => 'List',
+      'type' => MENU_DEFAULT_LOCAL_TASK,
+    );
+  }
+}
+
+/**
+ * Implements hook_og_ui_get_group_admin().
+ */
+function oa_access_og_ui_get_group_admin($group_type, $gid) {
+  $items = array();
+
+  if (module_exists('oa_teams') && og_user_access($group_type, $gid, 'administer oa_access permissions')) {
+    $items['oa_access'] = array(
+      'title' => t('Team access'),
+      'description' => t('Configure which Teams have which permissions.'),
+      'href' => 'admin/oa_access',
+    );
+  }
+
+  return $items;
+}
+
+/**
+ * Implements hook_strongarm_alter().
+ */
+function oa_access_strongarm_alter(&$items) {
+  if (isset($items['contextual_tabs_extract'])) {
+    $items['contextual_tabs_extract']->value .= "\n" . implode("\n", array(
+      "groups:Access,icon-user",
+      "List,icon-th-list",
+    ));
+  }
+}
+
+/**
+ * Implements hook_permission().
+ */
+function oa_access_permission() {
+  return array(
+    'administer oa_access permissions' => array(
+      'title' => t('Administer Open Atrium Access permissions'),
+      'description' => t('Allows users to configure which Groups have which permissions.'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_og_permission().
+ */
+function oa_access_og_permission() {
+  return array(
+    'administer oa_access permissions' => array(
+      'title' => t('Administer Open Atrium Access permissions'),
+      'description' => t('Allows users to configure which Teams have which permissions.'),
+      'default role' => array(OG_ADMINISTRATOR_ROLE),
+    ),
+  );
+}
+
+/**
+ * Implements hook_theme().
+ */
+function oa_access_theme() {
+  return array(
+    'oa_access_permissions_form' => array(
+      'render element' => 'permissions',
+      'file' => 'oa_access.theme.inc',
+    ),
+  );
+}
+
+/**
+ * Implements hook_node_delete().
+ */
+function oa_access_node_delete($node) {
+  db_delete('oa_access')
+    ->condition('nid', $node->nid)
+    ->execute();
+}
+
+/**
+ * Implements hook_modules_uninstalled().
+ */
+function oa_access_modules_uninstalled($modules) {
+  db_delete('oa_access')
+    ->condition('module', $modules, 'IN')
+    ->execute();
+}
+
+/**
+ * Get all permissions defined by implementing modules.
+ *
+ * @param boolean $reset
+ *   (Optional) If set to TRUE, it will reset the static cache.
+ *
+ * @return array
+ *   Associative array keyed with the permission name containing associative
+ *   arrays with the following keys:
+ *   - title: Human readable name of the permission.
+ *   - description: Human readable description of the permission.
+ *   - module: The machine name of the module which defines it.
+ *   - type: Flags specifying if can be used for Groups or Teams or both.
+ */
+function oa_access_get_permissions($reset = FALSE) {
+  if ($reset) {
+    drupal_static_reset(__FUNCTION__);
+  }
+  $perms =& drupal_static(__FUNCTION__, NULL);
+  if (is_null($perms)) {
+    $perms = array();
+    foreach (module_implements('oa_access_permission') as $module) {
+      if ($result = module_invoke($module, 'oa_access_permission')) {
+        foreach ($result as $key => $perm) {
+          $perms[$key] = array_merge($perm, array(
+            'module' => $module,
+          ));
+          if (empty($perms[$key]['type'])) {
+            $perms[$key]['type'] = OA_ACCESS_DEFAULT_PERMISSION;
+          }
+        }
+      }
+    }
+
+    drupal_alter('oa_access_permission', $perms);
+  }
+  return $perms;
+}
+
+/**
+ * Get a list of this user's Groups and Teams.
+ * 
+ * @param object|NULL $user 
+ *   (Optional) The user to get groups for. If NULL, it will find groups for
+ *   the currently logged in user.
+ * @param integer $space_nid 
+ *   (Optional) The nid of a Space. If given, this will include the Teams
+ *   from the given Space. If not given, then Teams won't be included.
+ *
+ * @return array
+ *   An associative array keyed by group nid containing associative arrays with
+ *   the following keys:
+ *   - nid: The group nid.
+ *   - type: The node type (ex: oa_group, oa_team).
+ */
+function oa_access_user_groups($account = NULL, $space_nid = 0) {
+  global $user;
+
+  if (is_null($account)) {
+    $account = $user;
+  }
+
+  $cache =& drupal_static(__FUNCTION__, array());
+
+  if (!isset($cache[$space_nid][$account->uid])) {
+    if (!isset($cache[0][$account->uid])) {
+      // First, get all the users oa_groups.
+      $query = db_select('og_membership', 'og');
+      $query->innerJoin('node', 'n', 'og.gid = n.nid');
+      $query
+        ->fields('n', array('nid', 'type'))
+        ->condition('og.group_type', 'node')
+        ->condition('og.entity_type', 'user')
+        ->condition('og.state', OG_STATE_ACTIVE)
+        ->condition('n.type', 'oa_group')
+        ->condition('og.etid', $account->uid);
+
+      $groups = array();
+      foreach ($query->execute() as $row) {
+        $groups[$row->nid] = array(
+          'nid'  => $row->nid,
+          'type' => $row->type,
+        );
+      }
+
+      $cache[0][$account->uid] = $groups;
+    }
+
+    if (module_exists('oa_teams') && $space_nid) {
+      $valid_teams = oa_teams_get_teams_for_space($space_nid);
+
+      // Then, we get all the user's oa_teams, optionally filtering by valid
+      // teams for this particular Space.
+      $query = db_select('field_data_' . OA_TEAM_USERS_FIELD, 'f')
+        ->fields('f', array('entity_id'))
+        ->condition('entity_type', 'node')
+        ->condition('deleted', 0)
+        ->condition(OA_TEAM_USERS_FIELD . '_target_id', $account->uid);
+
+      $teams = array();
+      foreach ($query->execute() as $row) {
+        // TODO: we could move this into the $query itself?
+        if (isset($valid_teams[$row->entity_id])) {
+          $teams[$row->entity_id] = array(
+            'nid' => $row->entity_id,
+            'type' => 'oa_team',
+          );
+        }
+      }
+
+      // Combine the cached Groups with the Teams to get the full result.
+      //$cache[$space_nid][$account->uid] = array_merge($cache[0][$account->uid], $teams);
+      $cache[$space_nid][$account->uid] = $cache[0][$account->uid] + $teams;
+    }
+  }
+
+  return $cache[$space_nid][$account->uid];
+}
+
+/**
+ * Gets all the permissions that a list of groups have.
+ *
+ * @param array $groups
+ *   An array of nids of Groups or Teams.
+ * 
+ * @return array
+ *   An associative array keyed by group nid containing associative arrays
+ *   keyed by the module and containing an array of permission names, for
+ *   example:
+ *   @code
+ *   array('27' => array('mymodule' => array('a permission')))
+ *   @endcode
+ *   Which signifies that the group with nid 27 has 'a permission' from
+ *   a module called 'mymodule'.
+ *
+ * @see oa_access_set_group_permissions()
+ */
+function oa_access_get_group_permissions($groups) {
+  $cache =& drupal_static(__FUNCTION__, array());
+
+  // First, go through the static cache and any groups we don't have data
+  // for to the $missing array.
+  $missing = array();
+  foreach ($groups as $gid) {
+    if (!isset($cache[$gid])) {
+      $missing[] = $gid;
+    }
+  }
+
+  // Next, query any of the missing groups from the database and add them to
+  // the static cache.
+  if (!empty($missing)) {
+    $query = db_select('oa_access', 'a')
+      ->fields('a', array('nid', 'permission', 'module'))
+      ->condition('a.nid', $missing, 'IN');
+    foreach ($query->execute() as $row) {
+      $cache[$row->nid][$row->module][] = $row->permission;
+    }
+  }
+
+  // Finally, add all the necessary permissions from the static cache and
+  // return it!
+  $return = array();
+  foreach ($groups as $gid) {
+    $return[$gid] = isset($cache[$gid]) ? $cache[$gid] : array();
+  }
+  return $return;
+}
+
+/**
+ * Changes the permissions for a set of groups.
+ *
+ * @param array $group_permissions
+ *   An associatiive array keyed by Group or Team nid containing associative
+ *   arrays keyed by module containing a list of permissions, for example:
+ *   @code
+ *   array('27' => array('mymodule' => array('a permission')))
+ *   @endcode
+ *   Which signifies that the group with nid 27 has 'a permission' from
+ *   a module called 'mymodule'.
+ *
+ * @see oa_access_get_group_permissions()
+ */
+function oa_access_set_group_permissions($group_permissions) {
+  $cache =& drupal_static('oa_access_get_group_permissions', array());
+
+  // Delete current permissions for the given groups.
+  db_delete('oa_access')
+    ->condition('nid', array_keys($group_permissions), 'IN')
+    ->execute();
+
+  // Then build them back up!
+  foreach ($group_permissions as $nid => $modules) {
+    foreach ($modules as $module => $permissions) {
+      foreach ($permissions as $name) {
+        db_insert('oa_access')
+          ->fields(array(
+            'nid' => $nid,
+            'permission' => $name,
+            'module' => $module,
+          ))
+          ->execute();
+      }
+      
+      // Replace these entries in the cache, so that we don't have to pull them
+      // from the database at all!
+      $cache[$nid] = $modules;
+    }
+  }
+}
+
+/**
+ * Gets a combined list of the permissions that a list of groups can perform.
+ *
+ * The permissions of all the groups are combined, such that if any group in
+ * the list has permission, it will be returned.
+ *
+ * @param array $groups
+ *   An array of nids of Groups or Teams.
+ * 
+ * @return array
+ *   @code
+ *   array('one permission' => TRUE, 'an other permission' => TRUE)
+ *   @endcode
+ *   Which signifies that the combined permissions of the given groups
+ *   include 'one permission' and 'an other permission'.
+ */
+function oa_access_get_group_permissions_combined($groups) {
+  $return = array();
+  foreach (oa_access_get_group_permissions($groups) as $gid => $modules) {
+    foreach ($modules as $perms) {
+      foreach ($perms as $name) {
+        $return[$name] = TRUE;
+      }
+    }
+  }
+  return $return;
+}
+
+/**
+ * Determines if the user has a permission.
+ *
+ * This is based on the user's membership in an Open Atrium Group or Team in
+ * the same way that user_access() is based on a user's membership in a role.
+ *
+ * @param object|NULL $space
+ *   The Space in which we want to perform the action. You can pass NULL if
+ *   there is no Space active (this will mean that Team permissions won't be
+ *   considered).
+ * @param string $permission
+ *   The machine name of the permission we are checking.
+ * @param object|NULL $account
+ *   (Optional) A user object representing the user to check. If NULL, it will
+ *   check for the currently logged in user.
+ *
+ * @returns boolean
+ *   TRUE if the user has permission; otherwise FALSE.
+ */
+function oa_access($space, $permission, $account = NULL) {
+  global $user;
+
+  if (is_null($account)) {
+    $account = $user;
+  }
+
+  // This function is most commonly called with the same $account but different
+  // $permissions's. So the layout of the static cache is optimized for that case.
+  //
+  // Also, when Teams come into play, access is dependent on the Space which the
+  // node belongs to. This is because permission gained by membership in a Team
+  // on Space A shouldn't give you that permission when editting content in
+  // Space B.
+  //
+  // So, the cache looks like this:
+  //
+  //   $cache[$space_nid][$account->uid][$permission] = TRUE;
+  //
+  // However, if oa_teams is disabled, we'll use a constant for $space_nid to
+  // group everything togather for a modest performance boost.
+  //
+  $cache =& drupal_static(__FUNCTION__, array());
+
+  $space_nid = !module_exists('oa_teams') ? 0 : ($space ? $space->nid : 0);
+
+  if (!isset($cache[$space_nid][$account->uid])) {
+    $groups = oa_access_user_groups($account, $space_nid);
+    $perms = oa_access_get_group_permissions_combined(array_keys($groups));
+    $cache[$space_nid][$account->uid] = $perms;
+  }
+
+  return isset($cache[$space_nid][$account->uid][$permission]);
+}
+
+/**
+ * Removes left over permissions that are no longer valid.
+ *
+ * @param string|NULL $module
+ *   (Optional) If specified it will only attempt to cleanup permissions for
+ *   the given module; otherwise it'll do them all.
+ */
+function oa_access_cleanup_permissions($module = NULL) {
+  $valid_permissions = oa_access_get_permissions();
+
+  $query = db_select('oa_access', 'a')
+    ->distinct()
+    ->fields('a', array('permission'));
+  if ($module) {
+    $query->condition('a.module', $module);
+  }
+  
+  // Find all the permissions in the database which aren't declared by
+  // hook_oa_access_permission().
+  $invalid = array();
+  foreach ($query->execute() as $row) {
+    if (!isset($valid_permissions[$row->permission])) {
+      $invalid[] = $row->permission;
+    }
+  }
+
+  // And delete them!
+  if (!empty($invalid)) {
+    db_delete('oa_access')
+      ->condition('permission', $invalid, 'IN')
+      ->execute();
+  }
+}

--- a/modules/oa_access/oa_access.theme.inc
+++ b/modules/oa_access/oa_access.theme.inc
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @file
+ * Theme functions for Open Atrium Access module.
+ */
+
+/**
+ * Returns HTML for the Group and Team permissions forms.
+ */
+function theme_oa_access_permissions_form($variables) {
+  $permissions = $variables['permissions'];
+  $first = NULL;
+
+  $rows = array();
+  foreach (element_children($permissions) as $module) {
+    $child_rows = array();
+    foreach (element_children($permissions[$module]) as $name) {
+      // Capture the first permission to use later for the table headers.
+      if (is_null($first)) {
+        $first = $permissions[$module][$name];
+      }
+
+      // Remove the individual labels, because they are going into the
+      // table header.
+      unset(
+        $permissions[$module][$name]['name']['#title'],
+        $permissions[$module][$name]['groups']['#title']
+      );
+
+      // Render them into the table row.
+      $child_rows[] = array(
+        array (
+          'data' => drupal_render($permissions[$module][$name]['name']),
+          'class' => array('permission'),
+        ),
+        drupal_render($permissions[$module][$name]['groups']),
+      );
+    }
+
+    // Render the parent row.
+    $rows[] = array(array(
+      'data' => drupal_render($permissions[$module]),
+      'class' => array('module'),
+      'id' => 'module-' . $permissions[$module]['#id'],
+      'colspan' => 2,
+    ));
+    // Merge in the child rows.
+    $rows = array_merge($rows, $child_rows);
+  }
+
+  if (count($rows) == 0) {
+    return '<p><em>' . t('No permissions available.') . '</em></p>';
+  }
+
+  // Build the table header.
+  $header = array(
+    $first['name']['#title'],
+    $first['groups']['#title'],
+  );
+  // Render the table.
+  $output  = theme('system_compact_link');
+  $output .= theme('table', array(
+    'header' => $header,
+    'rows' => $rows,
+    'attributes' => array(
+      // So that the theming for the standard user permission page is also
+      // used here.
+      'id' => 'permissions',
+    ),
+  ));
+  $output .= drupal_render_children($permissions);
+  return $output;
+}

--- a/modules/oa_access/tests/oa_access.test
+++ b/modules/oa_access/tests/oa_access.test
@@ -1,0 +1,592 @@
+<?php
+/**
+ * @file
+ * Functional tests for the Open Atrium Access module.
+ */
+
+/**
+ * Parent class for access control tests.
+ */
+abstract class OpenAtriumAccessBase extends DrupalWebTestCase {
+  /**
+   * Creates a node with an optional Space or Section.
+   *
+   * Replaces $this->drupalCreateNode() inside this test class.
+   *
+   * @param array $info
+   *   An associative array with information about the node which will
+   *   eventually get passed to node_save().
+   * @param object $space
+   *   (Optional) A Drupal node object representing the Space this node should
+   *   be created in.
+   * @param object $section
+   *   (Optional) A Drupal node object representing the Section this node
+   *   should be created in.
+   *
+   * @return object
+   *   The Drupal node object that was created.
+   *
+   * @see DrupalWebTestCase::drupalCreateNode()
+   */
+  protected function oaCreateNode($info, $space = NULL, $section = NULL) {
+    if ($space) {
+      $info['og_group_ref'][LANGUAGE_NONE][0]['target_id'] = $space->nid;
+    }
+    if ($section) {
+      $info['oa_section_ref'][LANGUAGE_NONE][0]['target_id'] = $section->nid;
+    }
+    return $this->drupalCreateNode($info);
+  }
+
+  /**
+   * Create a user with an optional Space.
+   *
+   * Replaces $this->drupalCreateUser() inside this test class.
+   *
+   * @param array $permissions
+   *   An array containing all the permissions this user should have.
+   * @param object $space
+   *   (Optional) A Drupal node object representing the Space this user should
+   *   be created in.
+   *
+   * @return object
+   *   The Drupal user object that was created.
+   *
+   * @see DrupalWebTestCase::drupalCreateUser()
+   */
+  protected function oaCreateUser($permissions, $space = NULL) {
+    $account = $this->drupalCreateUser($permissions);
+
+    if ($space) {
+      og_group('node', $space->nid, array(
+        'entity type' => 'user',
+        'entity' => $account,
+        'membership type' => OG_MEMBERSHIP_TYPE_DEFAULT,
+      ));
+    }
+
+    return $account;
+  }
+
+  /**
+   * Creates an Open Atrium Group with a new user in an optional Space.
+   *
+   * @param array $info
+   *   An associative array with information about the node which
+   *   will eventually get passed to node_save().
+   * @param array $permissions
+   *   An array containing all the permissions this user should have.
+   * @param object $space
+   *   (Optional) A Drupal node object representing the Space this user should
+   *   be created in.
+   *
+   * @return array
+   *   An associative array with two keys:
+   *   - group: (object) A Drupal node object representing the new Group node.
+   *   - user: (object) A Drupal user object representing the new user.
+   */
+  protected function oaCreateGroupWithUser(array $info, array $permissions, $space = NULL) {
+    $info += array(
+      'type' => 'oa_group',
+      'title' => 'Group',
+    );
+    $group = $this->oaCreateNode($info);
+    $account = $this->oaCreateUser($permissions, $space);
+
+    // Add the user to the group.
+    og_group('node', $group->nid, array(
+      'entity type' => 'user',
+      'entity' => $account,
+      'membership type' => OG_MEMBERSHIP_TYPE_DEFAULT,
+    ));
+
+    return array(
+      'group' => $group,
+      'user' => $account,
+    );
+  }
+
+  /**
+   * Creates an Open Atrium Team with a new user in a Space.
+   *
+   * @param array $info
+   *   An associative array with information about the node which
+   *   will eventually get passed to node_save().
+   * @param array $permissions
+   *   An array containing all the permissions this user should have.
+   * @param object $space
+   *   A Drupal node object representing the Space this Team and user should be
+   *   created in.
+   *
+   * @return array
+   *   An associative array with two keys:
+   *   - group: (object) A Drupal node object representing the new Group node.
+   *   - user: (object) A Drupal user object representing the new user.
+   */
+  protected function oaCreateTeamWithUser(array $info, array $permissions, $space) {
+    $info += array(
+      'type' => 'oa_team',
+      'title' => 'Team',
+    );
+    $team = $this->oaCreateNode($info, $space);
+    $account = $this->oaCreateUser($permissions, $space);
+
+    // Add the user to the team.
+    oa_teams_add_member($team, $account->uid);
+
+    return array(
+      'team' => $team,
+      'user' => $account,
+    );
+  }
+
+  /**
+   * Post to a Group/Team access page with a set of values.
+   *
+   * You're expected to use $this->drupalGet() to load the admin page before
+   * calling this function to submit.
+   *
+   * After posting to the admin form, it will verify that the permissions
+   * actually "stuck".
+   *
+   * @param array $values
+   *   An associative array keyed by the module machine name which contains
+   *   an associative array keyed by the permission machine name containing
+   *   arrays of group or team nids.
+   */
+  protected function oaPostPermissions($values) {
+    $edit = array();
+    foreach ($values as $module => $permissions) {
+      foreach ($permissions as $name => $groups) {
+        $edit["permissions[{$module}][{$name}][groups][]"] = $groups;
+      }
+    }
+    $this->drupalPost(NULL, $edit, t('Save permissions'));
+
+    // Verify that the settinsg 'stuck'.
+    foreach ($values as $module => $permissions) {
+      foreach ($permissions as $name => $groups) {
+        $results = $this->xpath('//select[@name=:name]//option', array(':name' => "permissions[{$module}][{$name}][groups][]"));
+        $found_groups = array();
+        foreach ($results as $option) {
+          if ($option['selected']) {
+            $found_groups[] = (string)$option['value'];
+          }
+        }
+        $this->assertEqual($found_groups, $groups, t('Settings for %permission stuck', array('%permission' => $name)));
+      }
+    }
+  }
+}
+
+/**
+ * Functional tests for the Open Atrium Access module.
+ */
+class OpenAtriumAccess extends OpenAtriumAccessBase {
+  public static function getInfo() {
+    return array(
+      'name' => 'Open Atrium Access',
+      'description' => 'Test the Open Atrium Access API.',
+      'group' => 'Open Atrium Access',
+    );
+  }
+
+  public function setUp() {
+    parent::setUp(array(
+      // Without oa_sections, we'll get a Table 'field_data_field_oa_user_ref'
+      // doesn't exist error. Although, we don't actually use Sections here. :-)
+      'oa_sections',
+      'oa_teams',
+      'oa_access_test',
+    ));
+
+    // Since we're not enabling oa_home, we need to make sure the front page
+    // exists, or $this->drupalLogin() will fail from the 404.
+    variable_set('site_frontpage', 'user');
+
+    // Flush all static caches.
+    $static_caches = array(
+      'oa_access',
+      'oa_access_user_groups',
+      'oa_access_get_group_permissions',
+      'oa_access_get_permissions',
+    );
+    foreach ($static_caches as $static_cache) {
+      drupal_static_reset($static_cache);
+    }
+  }
+
+  public function testGetPermissions() {
+    $this->assertEqual(oa_access_get_permissions(), array(
+      'access oa_access_test' => array(
+        'title' => t('Access Open Atrium Access Test'),
+        'description' => t('Gives you the ability to access Open Atrium Access Test'),
+        'module' => 'oa_access_test',
+        'type' => OA_ACCESS_DEFAULT_PERMISSION,
+      ),
+      'administer oa_access_test' => array(
+        'title' => t('Administer Open Atrium Access Test'),
+        'description' => t('Gives you the ability to administer Open Atrium Access Test'),
+        'module' => 'oa_access_test',
+        'type' => OA_ACCESS_DEFAULT_PERMISSION,
+      ),
+      'group permission for oa_access_test' => array(
+        'title' => t('A Group-only permission for Open Atrium Access Test'),
+        'description' => t('Used to test Group-only permissions'),
+        'module' => 'oa_access_test',
+        'type' => OA_ACCESS_GROUP_PERMISSION,
+      ),
+      'team permission for oa_access_test' => array(
+        'title' => t('A Team-only permission for Open Atrium Access Test'),
+        'description' => t('Used to test Team-only permissions'),
+        'module' => 'oa_access_test',
+        'type' => OA_ACCESS_TEAM_PERMISSION,
+      ),
+      'a permission for oa_access_test that is only conditionally available' => array(
+        'title' => t('Some fickle permission'),
+        'description' => t('A permission for oa_access_test that is only conditionally available'),
+        'module' => 'oa_access_test',
+        'type' => OA_ACCESS_DEFAULT_PERMISSION,
+      ),
+    ));
+  }
+
+  public function testUserGroups() {
+    // Create an admin user and login.
+    $account = $this->oaCreateUser(array('create oa_space content'));
+    $this->drupalLogin($account);
+
+    // Create a Space that all our users are going to belong to.
+    $space1 = $this->oaCreateNode(array(
+      'title' => 'Space A',
+      'type'  => 'oa_space',
+      'uid'   => $account->uid,
+    ));
+
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'), $space1);
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'), $space1);
+
+    // Add the user from $group_a to $group_b as well.
+    og_group('node', $group_b['group']->nid, array(
+      'entity type' => 'user',
+      'entity' => $group_a['user']->uid,
+      'membership type' => OG_MEMBERSHIP_TYPE_DEFAULT,
+    ));
+
+    // Now, create a Team in our Space and additionally add the user from
+    // $group_a to it.
+    $team_a = $this->oaCreateTeamWithUser(array('title' => 'Team A'), array('access content'), $space1);
+    oa_teams_add_member($team_a['team'], $group_a['user']->uid);
+
+    // Check the groups that the $group_a user belongs too (both including and
+    // excluding Teams).
+    $this->assertEqual(oa_access_user_groups($group_a['user']), array(
+      $group_a['group']->nid => array(
+        'nid' => $group_a['group']->nid,
+        'type' => 'oa_group',
+      ),
+      $group_b['group']->nid => array(
+        'nid' => $group_b['group']->nid,
+        'type' => 'oa_group',
+      ),
+    ));
+    $this->assertEqual(oa_access_user_groups($group_a['user'], $space1->nid), array(
+      $group_a['group']->nid => array(
+        'nid' => $group_a['group']->nid,
+        'type' => 'oa_group',
+      ),
+      $group_b['group']->nid => array(
+        'nid' => $group_b['group']->nid,
+        'type' => 'oa_group',
+      ),
+      $team_a['team']->nid => array(
+        'nid' => $team_a['team']->nid,
+        'type' => 'oa_team',
+      ),
+    ));
+
+    // Check the (much simpler) $group_b user.
+    $this->assertEqual(oa_access_user_groups($group_b['user']), array(
+      $group_b['group']->nid => array(
+        'nid' => $group_b['group']->nid,
+        'type' => 'oa_group',
+      ),
+    ));
+    $this->assertEqual(oa_access_user_groups($group_b['user'], $space1->nid), array(
+      $group_b['group']->nid => array(
+        'nid' => $group_b['group']->nid,
+        'type' => 'oa_group',
+      ),
+    ));
+
+    // And finally the $team_b user.
+    $this->assertEqual(oa_access_user_groups($team_a['user']), array());
+    $this->assertEqual(oa_access_user_groups($team_a['user'], $space1->nid), array(
+      $team_a['team']->nid => array(
+        'nid' => $team_a['team']->nid,
+        'type' => 'oa_team',
+      ),
+    ));
+  }
+
+  public function testGetSetGroupPermissions() {
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'));
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'));
+
+    $group_permissions = array(
+      $group_a['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test', 'administer oa_access_test')
+      ),
+      $group_b['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test'),
+      ),
+    );
+
+    // First, verify that there are no permissions set.
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), array(
+      $group_a['group']->nid => array(),
+      $group_b['group']->nid => array(),
+    ));
+
+    // Set the permissions in the database, then get them back out and make
+    // sure they are the same.
+    oa_access_set_group_permissions($group_permissions);
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), $group_permissions);
+
+    // We'll update only one of the groups permissions, but get both and make
+    // sure that we don't overwrite the wrong one.
+    $group_permissions[$group_b['group']->nid]['oa_access_test'] = array(
+      'administer oa_access_test',
+    );
+    $group_permissions_partial = $group_permissions;
+    unset($group_permissions_partial[$group_a['group']->nid]);
+    oa_access_set_group_permissions($group_permissions_partial);
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), $group_permissions);
+
+    // Now, clear the static cache on 'oa_access_get_group_permissions' and
+    // try it again - this will pull from the database.
+    drupal_static_reset('oa_access_get_group_permissions');
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), $group_permissions);
+  }
+
+  public function testCombinedGroupPermissions() {
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'));
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'));
+
+    $group_permissions = array(
+      $group_a['group']->nid => array(
+        'oa_access_test' => array('administer oa_access_test')
+      ),
+      $group_b['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test'),
+      ),
+    );
+    oa_access_set_group_permissions($group_permissions);
+
+    $group_permissions_combined = array(
+      'administer oa_access_test' => TRUE,
+      'access oa_access_test' => TRUE,
+    );
+    $this->assertEqual(oa_access_get_group_permissions_combined(array_keys($group_permissions)), $group_permissions_combined);
+  }
+
+  public function testGroupAccess() {
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'));
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'));
+    $not_in_group = $this->oaCreateUser(array('access content'));
+
+    $group_permissions = array(
+      $group_a['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test', 'administer oa_access_test')
+      ),
+      $group_b['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test'),
+      ),
+    );
+    oa_access_set_group_permissions($group_permissions);
+
+    // Make sure that each user has the permissions that they should.
+    $this->assertFalse(oa_access(NULL, 'access oa_access_test', $not_in_group));
+    $this->assertFalse(oa_access(NULL, 'administer oa_access_test', $not_in_group));
+    $this->assertTrue(oa_access(NULL, 'access oa_access_test', $group_a['user']));
+    $this->assertTrue(oa_access(NULL, 'administer oa_access_test', $group_a['user']));
+    $this->assertTrue(oa_access(NULL, 'access oa_access_test', $group_b['user']));
+    $this->assertFalse(oa_access(NULL, 'administer oa_access_test', $group_b['user']));
+  }
+
+  public function testTeamAccess() {
+    // Create an admin user and login.
+    $account = $this->oaCreateUser(array('create oa_space content'));
+    $this->drupalLogin($account);
+
+    // Create a Space that all our users are going to belong to.
+    $space1 = $this->oaCreateNode(array(
+      'title' => 'Space A',
+      'type'  => 'oa_space',
+      'uid'   => $account->uid,
+    ));
+
+    $team_a = $this->oaCreateTeamWithUser(array('title' => 'Team A'), array('access content'), $space1);
+    $team_b = $this->oaCreateTeamWithUser(array('title' => 'Team B'), array('access content'), $space1);
+    $not_in_group = $this->oaCreateUser(array('access content'));
+
+    $group_permissions = array(
+      $team_a['team']->nid => array(
+        'oa_access_test' => array('access oa_access_test', 'administer oa_access_test')
+      ),
+      $team_b['team']->nid => array(
+        'oa_access_test' => array('access oa_access_test'),
+      ),
+    );
+    oa_access_set_group_permissions($group_permissions);
+
+    // Make sure that each user has the permissions that they should.
+    $this->assertFalse(oa_access($space1, 'access oa_access_test', $not_in_group));
+    $this->assertFalse(oa_access($space1, 'administer oa_access_test', $not_in_group));
+    $this->assertTrue(oa_access($space1, 'access oa_access_test', $team_a['user']));
+    $this->assertTrue(oa_access($space1, 'administer oa_access_test', $team_a['user']));
+    $this->assertTrue(oa_access($space1, 'access oa_access_test', $team_b['user']));
+    $this->assertFalse(oa_access($space1, 'administer oa_access_test', $team_b['user']));
+
+    // Now, create a new Space which our users don't belong to and verify that
+    // they don't get any permissions there.
+    $space2 = $this->oaCreateNode(array(
+      'title' => 'Space B',
+      'type'  => 'oa_space',
+      'uid'   => $account->uid,
+    ));
+    $this->assertFalse(oa_access($space2, 'access oa_access_test', $team_a['user']));
+    $this->assertFalse(oa_access($space2, 'administer oa_access_test', $team_a['user']));
+    $this->assertFalse(oa_access($space2, 'access oa_access_test', $team_b['user']));
+    $this->assertFalse(oa_access($space2, 'administer oa_access_test', $team_b['user']));
+
+    // And, just for good measure, make sure they don't have these permissions
+    // when we aren't in any Space context.
+    $this->assertFalse(oa_access(NULL, 'access oa_access_test', $team_a['user']));
+    $this->assertFalse(oa_access(NULL, 'administer oa_access_test', $team_a['user']));
+    $this->assertFalse(oa_access(NULL, 'access oa_access_test', $team_b['user']));
+    $this->assertFalse(oa_access(NULL, 'administer oa_access_test', $team_b['user']));
+  }
+
+  public function testGroupAdminPage() {
+    // Create an admin user and login.
+    $account = $this->oaCreateUser(array('administer oa_access permissions'));
+    $this->drupalLogin($account);
+
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'));
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'));
+
+    // Configure Group A with both permissions, but Group B only with one.
+    $this->drupalGet(OA_ACCESS_GROUP_ADMIN_PATH);
+    $this->assertText(t('Used to test Group-only permissions'));
+    $this->assertNoText(t('Used to test Team-only permissions'));
+    $this->oaPostPermissions(array(
+      'oa_access_test' => array(
+        'access oa_access_test' => array($group_a['group']->nid, $group_b['group']->nid),
+        'administer oa_access_test' => array($group_a['group']->nid),
+        'group permission for oa_access_test' => array($group_a['group']->nid),
+      ),
+    ));
+
+    // Get permissions via the API and make sure they match.
+    $group_permissions = array(
+      $group_a['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test', 'administer oa_access_test', 'group permission for oa_access_test'),
+      ),
+      $group_b['group']->nid => array(
+        'oa_access_test' => array('access oa_access_test'),
+      ),
+    );
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), $group_permissions);
+  }
+
+  public function testTeamAdminPage() {
+    // Create an admin user and login.
+    $account = $this->oaCreateUser(array('administer oa_access permissions'));
+    $this->drupalLogin($account);
+
+    // Create a Space that all our users are going to belong to.
+    $space1 = $this->oaCreateNode(array(
+      'title' => 'Space A',
+      'type'  => 'oa_space',
+      'uid'   => $account->uid,
+    ));
+
+    $team_a = $this->oaCreateTeamWithUser(array('title' => 'Team A'), array('access content'), $space1);
+    $team_b = $this->oaCreateTeamWithUser(array('title' => 'Team B'), array('access content'), $space1);
+
+    // Configure Team A with both permissions, but Team B only with one.
+    $parts = explode('/', OA_ACCESS_TEAM_ADMIN_PATH);
+    $parts[1] = 'node';
+    $parts[2] = $space1->nid;
+    $this->drupalGet(implode('/', $parts));
+    $this->assertNoText(t('Used to test Group-only permissions'));
+    $this->assertText(t('Used to test Team-only permissions'));
+    $this->oaPostPermissions(array(
+      'oa_access_test' => array(
+        'access oa_access_test' => array($team_a['team']->nid, $team_b['team']->nid),
+        'administer oa_access_test' => array($team_a['team']->nid),
+        'team permission for oa_access_test' => array($team_a['team']->nid),
+      ),
+    ));
+
+    // Get permissions via the API and make sure they match.
+    $group_permissions = array(
+      $team_a['team']->nid => array(
+        'oa_access_test' => array('access oa_access_test', 'administer oa_access_test', 'team permission for oa_access_test'),
+      ),
+      $team_b['team']->nid => array(
+        'oa_access_test' => array('access oa_access_test'),
+      ),
+    );
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), $group_permissions);
+  }
+
+  public function testCleanupPermissions() {
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'));
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'));
+
+    // Add some groups with a permission available, that we're going to remove
+    // and then cleanup.
+    $group_permissions = array(
+      $group_a['group']->nid => array(
+        'oa_access_test' => array(
+          'a permission for oa_access_test that is only conditionally available',
+          'access oa_access_test'
+        ),
+      ),
+      $group_b['group']->nid => array(
+        'oa_access_test' => array(
+          'a permission for oa_access_test that is only conditionally available'
+        ),
+      ),
+    );
+    oa_access_set_group_permissions($group_permissions);
+
+    // Now, we remove the permission.
+    variable_set('oa_access_test_remove_permission', TRUE);
+    drupal_static_reset('oa_access_get_permissions');
+    $valid_permissions = oa_access_get_permissions();
+    $this->assertFalse(isset($valid_permissions['a permission for oa_access_test that is only conditionally available']));
+
+    // Before we do the clean-up, the removed permission will still be set for
+    // $group_a and $group_b. Clear the static cache to make sure we're getting
+    // the database version.
+    drupal_static_reset('oa_access_get_group_permissions');
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), $group_permissions);
+
+    // Perform the clean-up.
+    oa_access_cleanup_permissions();
+
+    // And now verify that the permissions have been removed.
+    drupal_static_reset('oa_access_get_group_permissions');
+    $this->assertEqual(oa_access_get_group_permissions(array_keys($group_permissions)), array(
+      $group_a['group']->nid => array(
+        'oa_access_test' => array(
+          'access oa_access_test'
+        ),
+      ),
+      $group_b['group']->nid => array(),
+    ));
+  }
+}

--- a/modules/oa_access/tests/oa_access_test/oa_access_test.info
+++ b/modules/oa_access/tests/oa_access_test/oa_access_test.info
@@ -1,0 +1,6 @@
+name = Open Atrium Access Test
+description = A test module to help with the unit tests for Open Atrium Access.
+package = Open Atrium
+core = 7.x
+hidden = TRUE
+dependencies[] = oa_access

--- a/modules/oa_access/tests/oa_access_test/oa_access_test.module
+++ b/modules/oa_access/tests/oa_access_test/oa_access_test.module
@@ -1,0 +1,47 @@
+<?php
+/**
+ * @file
+ * Module file for Open Atrium Access Test.
+ */
+
+/**
+ * Implements hook_oa_access_permission().
+ */
+function oa_access_test_oa_access_permission() {
+  $permissions = array(
+    'access oa_access_test' => array(
+      'title' => t('Access Open Atrium Access Test'),
+      'description' => t('Gives you the ability to access Open Atrium Access Test'),
+    ),
+    'administer oa_access_test' => array(
+      'title' => t('Administer Open Atrium Access Test'),
+      'description' => 'This will be replaced!',
+    ),
+    'group permission for oa_access_test' => array(
+      'title' => t('A Group-only permission for Open Atrium Access Test'),
+      'description' => t('Used to test Group-only permissions'),
+      'type' => OA_ACCESS_GROUP_PERMISSION,
+    ),
+    'team permission for oa_access_test' => array(
+      'title' => t('A Team-only permission for Open Atrium Access Test'),
+      'description' => t('Used to test Team-only permissions'),
+      'type' => OA_ACCESS_TEAM_PERMISSION,
+    ),
+  );
+  if (!variable_get('oa_access_test_remove_permission', FALSE)) {
+    $permissions['a permission for oa_access_test that is only conditionally available'] = array(
+      'title' => t('Some fickle permission'),
+      'description' => t('A permission for oa_access_test that is only conditionally available'),
+    );
+  }
+  return $permissions;
+}
+
+/**
+ * Implements hook_oa_access_permission_alter().
+ */
+function oa_access_test_oa_access_permission_alter(&$perm) {
+  if (isset($perm['administer oa_access_test'])) {
+    $perm['administer oa_access_test']['description'] = t('Gives you the ability to administer Open Atrium Access Test');
+  }
+}


### PR DESCRIPTION
This used by [oa_workbench_access](https://github.com/phase2/oa_workbench) (sub-module of [oa_workbench](https://github.com/phase2/oa_profile2)) and oa_profile2.

It's fully SimpleTest'ed and ready to go!

Please let me know what you think.
