### PR TITLE
Add version back to oa_core.

### DIFF
--- a/oa_core.info
+++ b/oa_core.info
@@ -2,6 +2,7 @@ name = Open Atrium Core
 description = Core required module for Open Atrium.
 core = 7.x
 package = Open Atrium
+version = 2.13
 project = oa_core
 dependencies[] = entityreference
 dependencies[] = features


### PR DESCRIPTION
Causes a [warning] when running certain drush commands if a module is basing a dependency on a certain version:

```
Open Atrium Work Tracker requires this module and version. Currently using Open Atrium Core version  (Currently using Unresolved dependency Open Atrium Core (Version &gt;2.10 required))
```
