### PR TITLE
Switched intermediate Space/Section views from 'page' display to 'system' display to preserve access checks.

### DIFF
--- a/modules/oa_sections/oa_sections.views_default.inc
+++ b/modules/oa_sections/oa_sections.views_default.inc
@@ -77,7 +77,8 @@ function oa_sections_views_default_views() {
   );
 
   /* Display: Page */
-  $handler = $view->new_display('page', 'Page', 'page');
+  $handler = $view->new_display('system', 'Page', 'page');
+  $handler->display->display_options['defaults']['access'] = FALSE;
   $handler->display->display_options['path'] = 'node/add/oa-section';
   $export['oa_sections_section_types'] = $view;
 

--- a/oa_core.info
+++ b/oa_core.info
@@ -3,6 +3,7 @@ description = Core required module for Open Atrium.
 core = 7.x
 package = Open Atrium
 project = oa_core
+dependencies[] = admin_views
 dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = file_entity

--- a/oa_core.views_default.inc
+++ b/oa_core.views_default.inc
@@ -73,7 +73,8 @@ function oa_core_views_default_views() {
   );
 
   /* Display: Page */
-  $handler = $view->new_display('page', 'Page', 'page');
+  $handler = $view->new_display('system', 'Page', 'page');
+  $handler->display->display_options['defaults']['access'] = FALSE;
   $handler->display->display_options['path'] = 'node/add/oa-space';
   $export['oa_core_space_types'] = $view;
 


### PR DESCRIPTION
I knew there was a way to do this! :-)

The admin_views module provides an alternative display plugin called 'system', that works just like 'page', except it designed for overriding existing pages and preserving access control. Switching to that appears to work! And looking at the entries on 'menu_router', the 'access callback' and 'access argmuments' look perfect.
