### PR TITLE
 Allow the links in the oa_user_badge to be modified

### DIFF
--- a/modules/oa_dashboard/oa_dashboard.module
+++ b/modules/oa_dashboard/oa_dashboard.module
@@ -154,7 +154,7 @@ function oa_dashboard_theme() {
 /**
  * Preprocess the OA Navigation.
  */
-function oa_dashboard_preprocess_oa_navigation(&$vars) {
+function template_preprocess_oa_navigation(&$vars) {
   if (variable_get('oa_mainmenu', TRUE)) {
     $menu = menu_tree_output(menu_tree_all_data($vars['menu_name'], NULL, 2));
 
@@ -173,7 +173,7 @@ function oa_dashboard_preprocess_oa_navigation(&$vars) {
 /**
  * Preprocess function for the oa_toolbar block.
  */
-function oa_dashboard_preprocess_oa_toolbar(&$vars) {
+function template_preprocess_oa_toolbar(&$vars) {
   global $user;
 
   drupal_add_js(drupal_get_path('module', 'oa_dashboard') . '/js/oa-dashboard.js');
@@ -409,21 +409,43 @@ function oa_dashboard_preprocess_oa_toolbar(&$vars) {
 /**
  * Preprocess function for the oa_breadcrumb.
  */
-function oa_dashboard_preprocess_oa_breadcrumb(&$vars) {
+function template_preprocess_oa_breadcrumb(&$vars) {
   $vars['show_parents'] = TRUE;
-  oa_dashboard_preprocess_oa_toolbar($vars);
+  template_preprocess_oa_toolbar($vars);
 }
 
 /**
  * Preprocess function for the oa_user_badge block.
  */
-function oa_dashboard_preprocess_oa_user_badge(&$vars) {
+function template_preprocess_oa_user_badge(&$vars) {
   global $user;
 
   if ($user->uid) {
     $user = user_load($user->uid);
     if (module_exists('oa_users')) {
       $vars = array_merge($vars, oa_users_build_user_details($user));
+
+      // Turn the links from oa_users_build_user_details() into a proper render
+      // array so that it can be modified.
+      $paths = $vars['links'];
+      $vars['links'] = array(
+        '#theme' => 'links',
+        '#links' => array(
+          'dashboard' => array(
+            'title'  => t('Dashboard'),
+            'href'   => $paths['dashboard'],
+          ),
+          'edit_profile' => array(
+            'title'  => t('Edit profile'),
+            'href'   => $paths['edit_profile'],
+          ),
+          'logout' => array(
+            'title'  => t('Log out'),
+            'href'   => $paths['logout'],
+            'weight' => 50,
+          ),
+        ),
+      );
     }
   }
   else {
@@ -435,7 +457,7 @@ function oa_dashboard_preprocess_oa_user_badge(&$vars) {
 /**
  * Preprocess function for the oa_toolbar_menu_button block.
  */
-function oa_dashboard_preprocess_oa_toolbar_menu_button(&$vars) {
+function template_preprocess_oa_toolbar_menu_button(&$vars) {
   drupal_add_js(drupal_get_path('module', 'oa_dashboard') . '/js/toolbar-menu-toggle.js');
 
   $vars['oa_toolbar_btn_class'] = 'btn-inverse';

--- a/modules/oa_dashboard/oa_dashboard.module
+++ b/modules/oa_dashboard/oa_dashboard.module
@@ -434,10 +434,12 @@ function template_preprocess_oa_user_badge(&$vars) {
           'dashboard' => array(
             'title'  => t('Dashboard'),
             'href'   => $paths['dashboard'],
+            'weight' => -10,
           ),
           'edit_profile' => array(
             'title'  => t('Edit profile'),
             'href'   => $paths['edit_profile'],
+            'weight' => -9,
           ),
           'logout' => array(
             'title'  => t('Log out'),

--- a/modules/oa_dashboard/oa_user_badge.tpl.php
+++ b/modules/oa_dashboard/oa_user_badge.tpl.php
@@ -20,11 +20,11 @@
         <?php print $picture; ?>
     </div>
     <div class="dropdown-menu" role="menu" aria-labelledby="section-dropdown">
-      <ul>
-        <li><?php print l(t('Dashboard'), $links['dashboard']); ?></li>
-        <li><?php print l(t('Edit profile'), $links['edit_profile']); ?></li>
-        <li><?php print l(t('Log out'), $links['logout']); ?></li>
-      </ul>
+      <?php
+        // Sort the links by 'weight' before rendering them.
+        uasort($links['#links'], 'drupal_sort_weight');
+        print render($links);
+      ?>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This is needed by the oa_workbench module to add the "My workbench" link to the user badge.

Also, this PR renames oa_dashboard_preprocess_\* functions to template_preprocess_\* for the theme callbacks the oa_dashboard defines. You can see these docs for the full info:

https://drupal.org/node/223430

But the short version is that a module should use template_preprocess_\* when it's the one defining that theme callback. The moduleName_preprocess_\* is for _other_ modules. It's pretty much the same difference between hook_blah() and hook_blah_alter() - the former runs first to setup the initial data and then subsequent ones can alter it.

I hope that makes sense!
