### PR TITLE
Cloning in Open Atrium (part 2!)

### DIFF
--- a/modules/oa_appearance/oa_appearance.module
+++ b/modules/oa_appearance/oa_appearance.module
@@ -234,3 +234,16 @@ function oa_appearance_edit_form_submit($form, &$form_state) {
   module_load_include('admin.inc', 'colorizer');
   colorizer_admin_form_submit($form, $form_state);
 }
+
+/**
+ * Implements hook_oa_clone_group_metadata().
+ */
+function oa_appearance_oa_clone_group_metadata($node, $original_nid) {
+  // Clone the colorizer values from the original.
+  foreach (list_themes() as $theme_name => $theme_info) {
+    if ($palette = variable_get('colorizer_' . $theme_name . '_' . $original_nid . '_palette', FALSE)) {
+      variable_set('colorizer_' . $theme_name . '_' . $node->nid . '_palette', $palette);
+      colorizer_update_stylesheet($theme_name, $theme_name . '_' . $node->nid, $palette);
+    }
+  }
+}

--- a/modules/oa_clone/oa_clone.api.php
+++ b/modules/oa_clone/oa_clone.api.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains documentation about the Open Atrium Clone module's hooks.
+ */
+
+/**
+ * @defgroup oa_clone Open Atrium Clone
+ * @{
+ * Hooks from the Open Atrium Clone module.
+ */
+
+/**
+ * Clone metadata associated with a Space or Group.
+ *
+ * This hook is called when cloning Space or Group, after the new node has
+ * been created but before any of it's content has been cloned. This is where
+ * your module should clone any metadata that it keeps about the Space or Group.
+ *
+ * If you want to clone some peice of data BEFORE the Space or Group node is
+ * saved (ie. so that your data is saved with it, rather than saving again) then
+ * you should hook_clone_node_alter() instead.
+ *
+ * @param object $node
+ *   Node object representing the Space or Group that we are going to configure.
+ * @param int $original_nid
+ *   The node ID of the original Space or Group we are cloning metadata from.
+ *
+ * @see hook_clone_node_alter()
+ */
+function hook_oa_clone_group_metadata($node, $original_nid) {
+  // Clone some data you are keeping about the node 
+  save_data_about_group($node->nid, load_data_about_group($original_nid));
+}
+
+/**
+ * @}
+ */

--- a/modules/oa_clone/oa_clone.info
+++ b/modules/oa_clone/oa_clone.info
@@ -8,7 +8,6 @@ dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = list
 dependencies[] = oa_buttons
-dependencies[] = og_clone
 dependencies[] = strongarm
 features[conditional_fields][] = taxonomy_term:space_type
 features[ctools][] = strongarm:strongarm:1

--- a/modules/oa_clone/oa_clone.module
+++ b/modules/oa_clone/oa_clone.module
@@ -17,6 +17,42 @@ define('OA_CLONE_ACTION_PATH', 'node/%node/clone/%clone_token');
 define('OA_CLONE_CREATE_SPACE_PATH', 'node/add/oa-space/%');
 
 /**
+ * Implements hook_menu().
+ */
+function oa_clone_menu() {
+  $items = array();
+  $items['node/%node/oa_clone_create_space_type'] = array(
+    'title' => 'Create Space Type from this Space',
+    'page callback' => 'oa_clone_create_space_type_page_callback',
+    'page arguments' => array(1),
+    'access callback' => 'oa_clone_create_space_type_access_callback',
+    'access arguments' => array(1),
+    'type' => MENU_LOCAL_TASK,
+  );
+  return $items;
+}
+
+/**
+ * Access callback: Check if the user can create a Space type from this node.
+ */
+function oa_clone_create_space_type_access_callback($node) {
+  $vid = taxonomy_vocabulary_machine_name_load('space_type')->vid;
+  return $node->type == 'oa_space' && user_access("edit terms in $vid") && node_access('view', $node);
+}
+
+/**
+ * Page callback: Redirect user to create a new Space type using a node.
+ */
+function oa_clone_create_space_type_page_callback($node) {
+  drupal_goto('admin/structure/taxonomy/space_type/add', array(
+    'query' => array(
+      'oa_clone_space' => $node->nid,
+      'destination' => "node/{$node->nid}",
+    ),
+  ));
+}
+
+/**
  * Implements hook_menu_alter().
  */
 function oa_clone_menu_alter(&$items) {
@@ -212,6 +248,386 @@ function oa_clone_clone_access_alter(&$access, $node) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function oa_clone_form_oa_space_node_form_alter(&$form, &$form_state, &$form_id) {
+function oa_clone_form_taxonomy_form_term_alter(&$form, &$form_state, $form_id) {
+  $vocabulary = $form['#vocabulary'];
+  if ($vocabulary->machine_name == 'space_type' && !empty($_GET['oa_clone_space']) && ($space = node_load($_GET['oa_clone_space']))) {
+    // Put the Space information in there by default.
+    $form['name']['#default_value'] = $space->title . ' ' . t('Space');
+    $form['description']['#default_value'] = t('A new Space that is just like @title.', array('@title' => $space->title));
+    $form['field_oa_clone_enabled'][LANGUAGE_NONE]['#default_value'] = TRUE;
+    $form['field_oa_clone_space'][LANGUAGE_NONE][0]['target_id']['#default_value'] = $space->title . " ({$space->nid})";
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function oa_clone_form_oa_space_node_form_alter(&$form, &$form_state) {
   $form['field_oa_space_type'][LANGUAGE_NONE]['#description'] = t('Changing the <em>Space type</em> after the Space has already been created, will only affect the default dashboard layout and available types - not content or configuration.');
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function oa_clone_form_node_form_alter(&$form, &$form_state) {
+  $node = $form['#node'];
+
+  // Fix a weird bug where the 'Other groups' field is always filled on clone
+  // with the same data as the 'Your groups' field. We just clear it out.
+  if (!empty($node->clone_from_original_nid) && isset($form['og_group_ref'][LANGUAGE_NONE][0]['admin'])) {
+    $form['og_group_ref'][LANGUAGE_NONE][0]['admin'][0]['target_id']['#default_value'] = '';
+  }
+}
+
+/**
+ * Implements hook_clone_node_alter().
+ */
+function oa_clone_clone_node_alter(&$node, $context) {
+  // At the moment we don't have much generic that affects all cloning
+  // operations. In general, you shouldn't put things here, but rather in the
+  // module that is responible for the thing you are adding support for.
+  // For example, sandbox support is done in oa_sandbox.
+
+  $original_node = $context['original_node'];
+  if (!empty($original_node->oa_clone_skip)) {
+    $node->oa_clone_skip = TRUE;
+  }
+}
+
+/**
+ * Prepares a node to be cloned via the 'clone' module.
+ *
+ * After you've made any changes, save it using oa_clone_save().
+ *
+ * @param object|int $original_node
+ *   The node object or nid that we are cloning.
+ * @param int $space_nid
+ *   (Optional) The nid of the Space to add this node to.
+ * @param int $section_nid
+ *   (Optional) The nid of the Section to add this node to.
+ * @param boolean $bypass_access_check
+ *   (Optional) If set to TRUE, the access check will be bypassed.
+ *
+ * @return object|NULL
+ *   The new node object that was created or NULL if the user doesn't have
+ *   access to clone it.
+ *
+ * @see oa_clone_save()
+ * @see oa_clone()
+ */
+function oa_clone_prepare($original_node, $space_nid = NULL, $section_nid = NULL, $bypass_access_check = FALSE) {
+  if (!is_object($original_node)) {
+    $original_node = node_load($original_node);
+    $original_node->oa_clone_skip = TRUE;
+  }
+
+  if ($bypass_access_check || clone_access_cloning($original_node)) {
+    module_load_include('inc', 'clone', 'clone.pages');
+
+    $node = _clone_node_prepare($original_node, FALSE);
+    if ($space_nid) {
+      if ($node->type == 'oa_space') {
+        $node->oa_parent_space[LANGUAGE_NONE][0]['target_id'] = $space_nid;
+      }
+      else {
+        $node->og_group_ref[LANGUAGE_NONE][0]['target_id'] = $space_nid;
+      }
+    }
+    if ($section_nid) {
+      $node->oa_section_ref[LANGUAGE_NONE][0]['target_id'] = $section_nid;
+    }
+
+    $context = array('method' => 'save-edit', 'original_node' => $original_node);
+    drupal_alter('clone_node', $node, $context);
+
+    return $node;
+  }
+}
+
+/**
+ * Saves a cloned node via the 'clone' module.
+ *
+ * You should have created the original $node object via the oa_clone_prepare()
+ * function.
+ *
+ * @param $node
+ *   The new node object to be saved.
+ *
+ * @see oa_clone_prepare()
+ * @see oa_clone()
+ */
+function oa_clone_save($node) {
+  node_save($node);
+  if (module_exists('rules')) {
+    rules_invoke_event('clone_node', $node, $original_node);
+  }
+}
+
+/**
+ * Clones a node using the 'clone' module.
+ *
+ * This is just a shortcut for calling oa_clone_prepare() and then
+ * oa_clone_save().
+ *
+ * @param object|int $original_node
+ *   The node object or nid that we are cloning.
+ * @param int $space_nid
+ *   (Optional) The nid of the Space to add this node to.
+ * @param int $section_nid
+ *   (Optional) The nid of the Section to add this node to.
+ * @param boolean $bypass_access_check
+ *   (Optional) If set to TRUE, the access check will be bypassed.
+ *
+ * @return object|NULL
+ *   The new node object that was created or NULL if the user doesn't have
+ *   access to clone it.
+ *
+ * @see oa_clone_prepare()
+ * @see oa_clone_save()
+ */
+function oa_clone($original_node, $space_nid = NULL, $section_nid = NULL, $bypass_access_check = FALSE) {
+  $node = oa_clone_prepare($original_node, $space_nid, $section_nid, $bypass_access_check);
+  if ($node) {
+    oa_clone_save($node);
+  }
+  return $node;
+}
+
+/**
+ * Gets all the content within a particular Section.
+ *
+ * @param int $nid
+ *   The node ID of the Section.
+ *
+ * @return array
+ *   An array of node IDs.
+ */
+function oa_clone_get_section_content($nid) {
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'node')
+    ->fieldCondition('oa_section_ref', 'target_id', $nid);
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    return array_keys($result['node']);
+  }
+  return array();
+}
+
+/**
+ * Gets all the memberships within a particular Group.
+ *
+ * @param int $nid
+ *   The node ID of the Group.
+ *
+ * @return array
+ *   An array of og_membership IDs.
+ */
+function oa_clone_get_group_memberships($nid) {
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'og_membership')
+    ->propertyCondition('group_type', 'node')
+    ->propertyCondition('gid', $nid)
+    ->propertyCondition('entity_type', 'user');
+  $result = $query->execute();
+  if (isset($result['og_membership'])) {
+    return array_keys($result['og_membership']);
+  }
+  return array();
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function oa_clone_node_insert($node) {
+  if (in_array($node->type, array('oa_section', 'oa_space', 'oa_group')) && !empty($node->clone_from_original_nid) && empty($node->oa_clone_skip)) {
+    $original_nid = $node->clone_from_original_nid;
+
+    $batch = array(
+      'title' => t('Cloning content...'),
+      'operations' => array(),
+      'finished' => 'oa_clone_batch_finished',
+    );
+
+    switch ($node->type) {
+      case 'oa_section':
+        $batch['operations'][] = array('oa_clone_batch_clone_section_content', array($node, $original_nid));
+        break;
+
+      case 'oa_space':
+        _oa_clone_batch_space($batch, $node, $original_nid);
+        break;
+
+      case 'oa_group':
+        $batch['operations'][] = array('oa_clone_batch_clone_group_memberships', array($node, $original_nid));
+        $batch['operations'][] = array('oa_clone_batch_clone_group_metadata', array($node, $original_nid));
+        break;
+    }
+
+    batch_set($batch);
+  }
+}
+
+/**
+ * Recursively clone a Space while setting up a batch for cloning content.
+ */
+function _oa_clone_batch_space(&$batch, $space, $original_space_nid) {
+  // Clone the OG metadata.
+  $batch['operations'][] = array('oa_clone_batch_clone_group_metadata', array($space, $original_space_nid));
+
+  // Clone all the Sections in this Space.
+  foreach (array_keys(oa_core_space_sections($original_space_nid)) as $original_section_nid) {
+    if ($clone_section = oa_clone($original_section_nid, $space->nid)) {
+      $batch['operations'][] = array('oa_clone_batch_clone_section_content', array($clone_section, $original_section_nid));
+    }
+  }
+
+  // Clone all sub-Spaces in this Space.
+  $associated_entities = og_subgroups_get_associated_entities('node', $original_space_nid);
+  if (!empty($associated_entities['node'])) {
+    foreach ($associated_entities['node'] as $original_subspace_nid) {
+      if ($clone_subspace = oa_clone($original_subspace_nid, $space->nid)) {
+        _oa_clone_batch_space($batch, $clone_subspace, $original_subspace_nid);
+      }
+    }
+  }
+
+  // TODO: Find all non-section / non-sub-space content in this Space and clone it.
+}
+
+/**
+ * Callback for cloning all the content in a section.
+ *
+ * @param object $node
+ *   Node object representing the Section we are going to popuplate.
+ * @param int $original_nid
+ *   The node ID of the original Section we are cloning data from.
+ * @param array &$context
+ *   A place where we can store values that need to b passed from one iteration
+ *   of this batch operation to the next.
+ */
+function oa_clone_batch_clone_section_content($node, $original_nid, &$context) {
+  // The first time through, set up all the variables.
+  if (empty($context['sandbox']['max'])) {
+    $context['sandbox']['content_ids'] = oa_clone_get_section_content($original_nid);
+    $context['sandbox']['max'] = count($context['sandbox']['content_ids']);
+    $context['sandbox']['nid'] = $node->nid;
+    $context['sandbox']['progress'] = 0;
+    $context['results']['total'] = (!empty($context['results']['total']) ? $context['results']['total'] : 0) + $context['sandbox']['max'];
+  }
+
+  // Get the next node.
+  $next_id = array_shift($context['sandbox']['content_ids']);
+  if (!$next_id) {
+    $context['sandbox']['finished'] = TRUE;
+    return;
+  }
+
+  // Get the original node and mark it so that it doesn't get cloned again.
+  $original_node = node_load($next_id);
+  $original_node->oa_clone_skip = TRUE;
+
+  // Clone it, setting to the new Space and Section.
+  $clone = oa_clone($original_node, $node->og_group_ref[LANGUAGE_NONE][0]['target_id'], $node->nid);
+  // Remeber: $clone can be NULL, if the user doesn't have permission to clone this node!
+
+  // Bump the progress indicator.
+  $context['sandbox']['progress']++;
+
+  // Report progress if not finished and run again.
+  $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+}
+
+/**
+ * Callback for cloning all the memberships in a group.
+ *
+ * @param object $node
+ *   Node object representing the Group we are going to popuplate.
+ * @param int $original_nid
+ *   The node ID of the original Group we are cloning data from.
+ * @param array &$context
+ *   A place where we can store values that need to b passed from one iteration
+ *   of this batch operation to the next.
+ */
+function oa_clone_batch_clone_group_memberships($node, $original_nid, &$context) {
+  // The first time through, set up all the variables.
+  if (empty($context['sandbox']['max'])) {
+    $context['sandbox']['membership_ids'] = oa_clone_get_group_memberships($original_nid);
+    $context['sandbox']['max'] = count($context['sandbox']['membership_ids']);
+    $context['sandbox']['gid'] = $node->nid;
+    $context['sandbox']['progress'] = 0;
+  }
+
+  // Get the next node.
+  $next_id = array_shift($context['sandbox']['membership_ids']);
+  if (!$next_id) {
+    $context['sandbox']['finished'] = TRUE;
+    return;
+  }
+
+  // Clone the original membership, change it to the new group and save.
+  $original_membership = og_membership_load($next_id);
+  $membership = clone $original_membership;
+  $membership->id = NULL;
+  $membership->gid = $node->nid;
+  og_membership_save($membership);
+
+  // Bump the progress indicator.
+  $context['sandbox']['progress']++;
+
+  // Report progress if not finished and run again.
+  $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['max'];
+}
+
+/**
+ * Callback for cloning Organic Groups metadata (variables, permisssions, etc).
+ *
+ * @param object $node
+ *   Node object representing the Space or Group that we are going to configure.
+ * @param int $original_nid
+ *   The node ID of the original Space or Group we are cloning metadata from.
+ * @param array &$context
+ *   A place where we can store values that need to b passed from one iteration
+ *   of this batch operation to the next.
+ */
+function oa_clone_batch_clone_group_metadata($node, $original_nid, &$context) {
+  // Clone OG variables.
+  foreach (variable_realm_controller('og')->getEnabledVariables() as $name) {
+    variable_realm_set('og', 'node_' . $node->nid, $name, variable_realm_get('og', 'node_' . $original_nid, $name));
+  }
+
+  // Clone OG roles.
+  $original_role_map = array();
+  $original_roles = og_roles('node', $node->type, $original_nid);
+  foreach ($original_roles as $original_rid => $original_name) {
+    $original_role_map[$original_name] = $original_rid;
+    // If this is a custom role, then we have to create it.
+    if (!in_array($original_name, array(OG_ANONYMOUS_ROLE, OG_AUTHENTICATED_ROLE, OG_ADMINISTRATOR_ROLE))) {
+      $role = og_role_create($original_name, 'node', $node->nid, $node->type);
+      og_role_save($role);
+    }
+  }
+
+  // Clone OG permissions.
+  $permissions = og_role_permissions($original_roles);
+  foreach (og_roles('node', $node->type, $node->nid) as $rid => $name) {
+    og_role_change_permissions($rid, $permissions[$original_role_map[$name]]);
+  }
+
+  // Allow other modules to copy group metadata too.
+  module_invoke_all('oa_clone_group_metadata', $node, $original_nid);
+}
+
+/**
+ * Callback for when cloning batch finishes.
+ */
+function oa_clone_batch_finished($success, $results, $operations) {
+  if ($success) {
+    $total = !empty($results['total']) ? $results['total'] : 0;
+    drupal_set_message(t('Finished cloning @num_ids peices of content successfully.', array('@num_ids' => $total + 1)));
+  }
+  else {
+    drupal_set_message(t('Error cloning content.'), 'error');
+  }
 }

--- a/modules/oa_dashboard/oa_dashboard.module
+++ b/modules/oa_dashboard/oa_dashboard.module
@@ -152,6 +152,47 @@ function oa_dashboard_theme() {
 }
 
 /**
+ * Get jump links to create Spaces/Sections of a particular type.
+ *
+ * @param string $base
+ *   Either the string 'space' or 'section'.
+ * @param array $url_query
+ *   Associative array to use as the URL query string.
+ * 
+ * @return string|NULL
+ *   Returns a string containing the rendered jump links or NULL if there are
+ *   less than 2 links.
+ */
+function oa_dashboard_get_jump_links($base, $url_query = array()) {
+  $vocab_name = $base . '_type';
+  $node_type = 'oa-' . $base;
+
+  // Get all the type terms.
+  $query = db_select('taxonomy_term_data', 'td');
+  $query->join('taxonomy_vocabulary', 'v', 'v.vid = td.vid');
+  $query
+    ->fields('td', array('tid', 'name'))
+    ->condition('v.machine_name', $vocab_name);
+  $terms = $query->execute()->fetchAllKeyed();
+
+  if (count($terms) > 1) {
+    $links = array();
+    foreach ($terms as $tid => $name) {
+      $links[] = array(
+        'title' => t('Create new @type', array('@type' => $name)),
+        'href' => "node/add/{$node_type}/$tid",
+        'query' => $url_query,
+      );
+    }
+
+    return theme('links', array(
+      'links' => $links,
+      'attributes' => array('class' => array('dropdown-menu')),
+    ));
+  }
+}
+
+/**
  * Preprocess the OA Navigation.
  */
 function template_preprocess_oa_navigation(&$vars) {
@@ -287,8 +328,12 @@ function template_preprocess_oa_toolbar(&$vars) {
       $show_all);
   }
   if (user_access('create ' . $space_type . ' content', $user)) {
-    $list[] = l(t('Create new ' . $space_type_name), 'node/add/' . str_replace('_', '-', $space_type),
-      array('attributes' => array('class' => array('more-link'))));
+    $jump_links = oa_dashboard_get_jump_links('space');
+    $list[] = array(
+      'data' => l(t('Create new ' . $space_type_name), 'node/add/' . str_replace('_', '-', $space_type),
+        array('attributes' => array('class' => array('more-link')))) . $jump_links,
+      'class' => !empty($jump_links) ? array('dropdown-submenu') : array(),
+    );
   }
   if (!empty($list)) {
     $vars['home_spaces'] = theme('item_list', array(
@@ -342,11 +387,15 @@ function template_preprocess_oa_toolbar(&$vars) {
         }
       }
       if (module_exists('oa_subspaces') && og_user_access('node', $space_id, 'create ' . OA_SPACE_TYPE . ' content', $user)) {
-        $add_subspace = l(t('Create new subspace'), 'node/add/' . str_replace('_', '-', OA_SPACE_TYPE),
-          array(
-            'attributes' => array('class' => array('more-link')),
-            'query' => array(OA_PARENT_SPACE => $space_id),
-          ));
+        $jump_links = oa_dashboard_get_jump_links('space', array(OA_PARENT_SPACE => $space_id));
+        $add_subspace = array(
+          'data' => l(t('Create new subspace'), 'node/add/' . str_replace('_', '-', OA_SPACE_TYPE),
+            array(
+              'attributes' => array('class' => array('more-link')),
+              'query' => array(OA_PARENT_SPACE => $space_id),
+            )) . $jump_links,
+          'class' => !empty($jump_links) ? array('dropdown-submenu') : array(),
+        );
         if (!empty($subspace_list)) {
           $subspace_list[] = $add_subspace;
         }
@@ -355,8 +404,12 @@ function template_preprocess_oa_toolbar(&$vars) {
         }
       }
       if (og_user_access('node', $space_id, "create " . OA_SECTION_TYPE . " content", $user)) {
-        $items[] = l(t('Create new section'), 'node/add/' . str_replace('_', '-', OA_SECTION_TYPE),
-          array('attributes' => array('class' => array('more-link'))));
+        $jump_links = oa_dashboard_get_jump_links('section');
+        $items[] = array(
+          'data' => l(t('Create new section'), 'node/add/' . str_replace('_', '-', OA_SECTION_TYPE),
+            array('attributes' => array('class' => array('more-link')))) . $jump_links,
+          'class' => !empty($jump_links) ? array('dropdown-submenu') : array(),
+        );
       }
       if (!empty($items)) {
         $vars['sections_list'] = theme('item_list', array(

--- a/modules/oa_sandbox/oa_sandbox.module
+++ b/modules/oa_sandbox/oa_sandbox.module
@@ -118,12 +118,13 @@ function oa_sandbox_delete_confirm_submit($form, &$form_state) {
  * Alter the node add/edit form by adding the new "Test Content" checkbox to it.
  */
 function oa_sandbox_form_node_form_alter(&$form, &$form_state, $form_id) {
+  $node = $form['#node'];
   $form['options']['sandbox'] = array(
     '#type' => 'checkbox',
     '#weight' => 10,
     '#title' => t('Test content'),
     '#description' => t('Should this be considered test content? If checked, this will be deleted/reverted when sandbox mode is turned off.'),
-    '#default_value' => variable_get('oa_sandbox_mode', 0),
+    '#default_value' => !empty($node->sandbox) ? $node->sandbox : variable_get('oa_sandbox_mode', 0),
   );
   $form['#validate'][] = 'oa_sandbox_form_node_form_validate';
 }
@@ -134,6 +135,16 @@ function oa_sandbox_form_node_form_alter(&$form, &$form_state, $form_id) {
 function oa_sandbox_form_node_form_validate($form, &$form_state) {
   if ($form_state['values']['sandbox'] && !$form_state['values']['revision']) {
     $form_state['values']['revision'] = TRUE;
+  }
+}
+
+/**
+ * Implements hook_node_load().
+ */
+function oa_sandbox_node_load($nodes, $types) {
+  $sandbox_revisions = variable_get('oa_sandbox_revisions', array());
+  foreach ($nodes as $nid => $node) {
+    $nodes[$nid]->sandbox = isset($sandbox_revisions[$nid]);
   }
 }
 
@@ -176,6 +187,14 @@ function oa_sandbox_node_update($node) {
  */
 function oa_sandbox_node_insert($node) {
   oa_sandbox_node_update($node);
+}
+
+/**
+ * Implementation of hook_clone_node_alter().
+ */
+function oa_sandbox_clone_node_alter(&$node, $context) {
+  $original = $context['original_node'];
+  $node->sandbox = $original->sandbox ? $original->sandbox : variable_get('oa_sandbox_mode', 0);
 }
 
 /**

--- a/oa_core.make
+++ b/oa_core.make
@@ -266,13 +266,6 @@ projects[og_session_context][subdir] = contrib
 projects[og_menu_single][version] = 1.0-beta1
 projects[og_menu_single][subdir] = contrib
 
-; Og clone
-projects[og_clone][version] = 1.x-dev
-projects[og_clone][subdir] = contrib
-projects[og_clone][download][type] = git
-projects[og_clone][download][branch] = 7.x-1.x
-projects[og_clone][download][revision] = 66ad62b
-
 ; ##### oa_variables #####
 ; Variable
 projects[variable][version] = 2.3


### PR DESCRIPTION
This is the mythical part 2 of my cloning in Open Atrium work. :-)

This does a number of things:
1. **Removes dependency on og_clone and implements Atrium-specific "child content cloning" logic.** og_clone basically just looped through all the group content and cloned it too. However, Open Atrium's content is highly heirarchical and so this actually didn't work correctly. You need to clone Spaces before Sections, and Sections before their content, parent Discussion posts before replies, etc -- so that each could be attached to the new parent. I think the architecture used is pretty strong and should allow us to continue to extend it as Atrium evolves.
2. **Clones some more Atrium/OG metadata about Spaces.** This will now correctly clone OG variables, OG roles and permissions, Atrium appearance settings (ie. colorizer), and the "Test content" flag (ie. if you clone test content, it will also be test content).
3. **Clones Group memberships when cloning Groups.** Groups are basically containers for membership, so cloning them without cloning the memberships is pretty useless. :-) The new version will clone Group memberships, but not Space memberships.
4. **Adds jump links for fast creation of Spaces/Sections.** If more than one Space or Section type exists, it will add "jump links" to the smart breadcrumbs. ![selection_005](https://f.cloud.github.com/assets/191561/2234337/b448fe7a-9b36-11e3-927c-8a71e778b0b1.png)
5. **Adds a "Create Space Type from this Space" link for users with enough permission.** Basically, just a convenience link to take them to the "Add term" form, filling in the the Space to clone automatically. ![selection_007](https://f.cloud.github.com/assets/191561/2234341/de68670e-9b36-11e3-859c-957923280f0c.png)

I did TONs of testing on this and lots of things work as they should! I tried cloning just Sections, whole Spaces, Spaces with sub-Spaces, various Atrium content types, etc. Many things just plain worked without extra code! For example, all the banner stuff and pretty much anything with fields. However, I'm sure this could use more testing.

However, even without extra testing, this code is objectively better than what's already committed! Without the changes for point 1 above, the cloning is basically broken and does some really unexpected things, for example: it would clone a node into a new Space, but leaves it's Section ref pointing at the old Section in the old Space. So, I'd recommend committing this right away even if it isn't perfect.

There's one major thing that I know the current code DOESN'T clone and that's OG menus. It's challenging because the menu heirarchy could be different than the content heirarchy and we need to be sure to clone parent menu items before children, which means keeping track of the mapping between old content and new content while cloning and then creating the new OG menu in a second pass afterwards. I have some ideas about how to do this, but haven't had time to act on them yet.

And one final note: I'll be posting a seperate PR for adding cloning support to oa_discussions. Without that PR, oa_discussions has some pretty strange behavior (I'll explain on that PR).

Anyway, I'm pretty excited about this functionality! Please let me know what you think! :-)
