### PR TITLE
Inherit banner and colorizer settings from parent Spaces.

### DIFF
--- a/modules/oa_appearance/oa_appearance.module
+++ b/modules/oa_appearance/oa_appearance.module
@@ -23,7 +23,7 @@ define('OA_SPACE_BANNER_SPACE_MENU', 4);
  */
 function oa_appearance_colorizer_instance_alter(&$instance) {
   $space_id = oa_core_get_space_home_context();
-  $instance = $instance . '_' . $space_id;
+  $instance = oa_appearance_get_space_colorizer_instance($instance, $space_id);
 }
 
 /**
@@ -210,6 +210,13 @@ function oa_appearance_edit_form($form, &$form_state, $entity_type, $entity_id) 
   module_load_include('admin.inc', 'colorizer');
 
   $form = colorizer_admin_form(FALSE, FALSE);
+  $form['#entity_type'] = $entity_type;
+  $form['#entity_id'] = $entity_id;
+
+  // We always write to the current Spaces instance, even if we are inheriting
+  // the current colors from the parent. This allows us to switch to our local
+  // settings by saving this form.
+  $form['instance']['#value'] = $GLOBALS['theme'] . '_' . $entity_id;
 
   $form['submit'] = array(
     '#type' => 'submit',
@@ -237,6 +244,20 @@ function oa_appearance_edit_form_validate($form, &$form_state) {
 function oa_appearance_edit_form_submit($form, &$form_state) {
   module_load_include('admin.inc', 'colorizer');
   colorizer_admin_form_submit($form, $form_state);
+
+  // Clear the colorizer instance static cache.
+  drupal_static_reset('oa_appearance_get_space_colorizer_instance');
+
+  // Clear our colorizer instance cache.
+  $nid = $form['#entity_id'];
+  cache_clear_all("oa_appearance:colorizer:{$nid}", "cache");
+
+  // Clear the colorizer instance cache for all child spaces as well.
+  if (module_exists("oa_subspaces")) {
+    foreach (oa_subspaces_get_children_groups("node", $nid) as $child_nid) {
+      cache_clear_all("oa_appearance:colorizer:{$child_nid}", "cache");
+    }
+  }
 }
 
 /**
@@ -400,4 +421,54 @@ function oa_appearance_get_space_banner($space_id, $banner_position) {
   }
 
   return $static_cache[$static_cache_key];
+}
+
+/**
+ * Get the colorizer instance name.
+ *
+ * Takes the parent Spaces and inheritence into account. Resulting values will
+ * be cached until the Space or any of it's parents are updated.
+ *
+ * @param string $instance_base
+ *   The base name of the colorizer instance.
+ * @param integer $space_id
+ *   The NID of the Space.
+ *
+ * @return string
+ *   The full instance name.
+ */
+function oa_appearance_get_space_colorizer_instance($base_instance, $space_id) {
+  $static_cache =& drupal_static(__FUNCTION__, array());
+
+  if (!isset($static_cache[$space_id])) {
+    $cid = 'oa_appearance:colorizer:' . $space_id;
+    if ($cached_value = cache_get($cid)) {
+      $static_cache[$space_id] = $cached_value->data;
+    }
+    
+    if (!isset($static_cache[$space_id])) {
+      $space = node_load($space_id);
+
+      $instance = $base_instance . '_' . $space_id;
+
+      // If there is no instance for the current Space, then try it's parent.
+      if (variable_get("colorizer_{$instance}_palette", FALSE) === FALSE && module_exists('oa_subspaces')) {
+        $parent = field_get_items('node', $space, OA_PARENT_SPACE);
+        $parent = !empty($parent[0]['target_id']) ? node_load($parent[0]['target_id']) : NULL;
+        if ($parent && $parent->type == 'oa_space') {
+          $instance = oa_appearance_get_space_colorizer_instance($base_instance, $parent->nid);
+        }
+        else {
+          // If we are at the top-level (ie. there is no parent), then we
+          // fallback on the site-wide default.
+          $instance = $base_instance;
+        }
+      }
+
+      $static_cache[$space_id] = $instance;
+      cache_set($cid, $instance);
+    }
+  }
+
+  return $static_cache[$space_id];
 }

--- a/modules/oa_appearance/oa_appearance.module
+++ b/modules/oa_appearance/oa_appearance.module
@@ -452,7 +452,7 @@ function oa_appearance_get_space_colorizer_instance($base_instance, $space_id) {
       $instance = $base_instance . '_' . $space_id;
 
       // If there is no instance for the current Space, then try it's parent.
-      if (variable_get("colorizer_{$instance}_palette", FALSE) === FALSE && module_exists('oa_subspaces')) {
+      if ($space && variable_get("colorizer_{$instance}_palette", FALSE) === FALSE && module_exists('oa_subspaces')) {
         $parent = field_get_items('node', $space, OA_PARENT_SPACE);
         $parent = !empty($parent[0]['target_id']) ? node_load($parent[0]['target_id']) : NULL;
         if ($parent && $parent->type == 'oa_space') {

--- a/modules/oa_appearance/oa_appearance.module
+++ b/modules/oa_appearance/oa_appearance.module
@@ -175,6 +175,8 @@ function oa_appearance_form_oa_core_configure_form_alter(&$form, &$form_state, $
     '#title' => 'Show site slogan',
     '#default_value' => variable_get('oa_banner_siteslogan', FALSE),
   );
+
+  $form['#submit'][] = 'oa_appearance_banner_submit';
 }
 
 function oa_appearance_banner_validate($element, &$form_state, $form) {
@@ -194,6 +196,11 @@ function oa_appearance_banner_validate($element, &$form_state, $form) {
       variable_set('oa_site_banner', $fid);
     }
   }
+}
+
+function oa_appearance_banner_submit($form, &$form_state) {
+  // Clear the banner settings cache for all Spaces.
+  cache_clear_all("oa_appearance:banner:", "cache", TRUE);
 }
 
 /**
@@ -243,4 +250,154 @@ function oa_appearance_oa_clone_group_metadata($node, $original_nid) {
       colorizer_update_stylesheet($theme_name, $theme_name . '_' . $node->nid, $palette);
     }
   }
+}
+
+/**
+ * Implements hook_node_update().
+ */
+function oa_appearance_node_update($node) {
+  if ($node->type == 'oa_space') {
+    // Clear our banner settings cache.
+    cache_clear_all("oa_appearance:banner:{$node->nid}:", "cache", TRUE);
+
+    // Clear the banner settings cache for all child spaces as well.
+    if (module_exists("oa_subspaces")) {
+      foreach (oa_subspaces_get_children_groups("node", $node->nid) as $child_nid) {
+        cache_clear_all("oa_appearance:banner:{$child_nid}:", "cache", TRUE);
+      }
+    }
+  }
+}
+
+/**
+ * Get the banner settings for a particular Space.
+ *
+ * Takes the parent Spaces and inheritence into account. Resulting values will
+ * be cached until the Space or any of it's parents are updated.
+ *
+ * @param integer $space_id
+ *   The NID of the Space.
+ * @param integer $banner_position
+ *   The banner position to get settings for. Can be either:
+ *   - OA_SPACE_BANNER_ABOVE
+ *   - OA_SPACE_BANNER_BELOW
+ *
+ * @return array
+ *   An associative array of the banner settings:
+ *   - position (string): Constant representing the banner position.
+ *   - image (array): Image field item representing the banner image.
+ *   - text (string): The banner text.
+ */
+function oa_appearance_get_space_banner($space_id, $banner_position) {
+  global $base_url;
+
+  $static_cache =& drupal_static(__FUNCTION__, array());
+  $static_cache_key = $space_id . ':' . $banner_position;
+
+  if (!isset($static_cache[$static_cache_key])) {
+    $cid = 'oa_appearance:banner:' . $static_cache_key;
+    if ($cached_value = cache_get($cid)) {
+      $static_cache[$static_cache_key] = $cached_value->data;
+    }
+    
+    if (!isset($static_cache[$static_cache_key])) {
+      $space = node_load($space_id);
+
+      // Default banner settings.
+      $banner = array(
+        'position' => 0,
+        'image' => array(),
+        'text' => '',
+        'slogan' => '',
+        'stretch' => FALSE,
+      );
+
+      // The site-wide banner position.
+      $site_position = variable_get('oa_site_banner_position', 0);
+
+      // Get the Space's 'Banner position'. If it's set to '- None -', then we
+      // take the site's 'Banner position' - which is different than 'Hidden',
+      // ie. a position of 0.
+      $space_position = field_get_items('node', $space, OA_SPACE_BANNER_POSITION);
+      $space_position = isset($space_position[0]['value']) ? $space_position[0]['value'] : $site_position;
+
+      // Only attempt to figure out the banner settings if the Space's
+      // 'Banner position' isn't set to 'Hidden'.
+      if ($space_position != 0) {
+        // First, check if the Space is overriding the banner image. If so, we
+        // use its banner settings.
+        $space_image = field_get_items('node', $space, 'field_oa_banner');
+        $space_image = !empty($space_image) ? $space_image[0] : NULL;
+        if ($space_image && $space_position == $banner_position) {
+          $banner['position'] = $space_position;
+
+          $banner['image'] = array(
+            'path' => $space_image['uri'],
+            'width' => $space_image['width'],
+            'height' => $space_image['height'],
+            'alt' => $space_image['alt'],
+            'attributes' => array(
+              'class' => 'oa-banner-overlay-img',
+            ),
+          );
+
+          $space_text = field_view_field('node', $space, 'field_oa_banner_text', array('label' => 'hidden'));
+          if (!empty($space_text)) {
+            $banner['text'] = drupal_render($space_text);
+          }
+        }
+        // If the Space doesn't override, then pull the parent's settings. If
+        // there is no parent, then these are the site-wide settings.
+        else {
+          $parent = module_exists('oa_subspaces') ? field_get_items('node', $space, OA_PARENT_SPACE) : NULL;
+          $parent = !empty($parent[0]['target_id']) ? node_load($parent[0]['target_id']) : NULL;
+          if ($parent && $parent->type == 'oa_space') {
+            $banner = oa_appearance_get_space_banner($parent->nid, $banner_position);
+          }
+          // The site-wide settings only apply if we are doing the same position
+          // as the position of the site-wide banner.
+          elseif ($banner_position == variable_get('oa_site_banner_position', 0)) {
+            $banner['position'] = $site_position;
+
+            // Get the site-wide image.
+            $site_stretch = variable_get('oa_banner_stretch', FALSE);
+            $site_file = NULL;
+            $site_fid = variable_get('oa_site_banner', '');
+            if ($site_fid && ($site_file = file_load($site_fid))) {
+              // Banner successfully loaded.
+            }
+            elseif (variable_get('oa_banner_default', TRUE)) {
+              // Use the default banner image.
+              $site_file = new stdClass();
+              $site_file->uri = $base_url . '/' . drupal_get_path('module', 'oa_widgets') . '/openatrium-powered.png';
+              $site_file->metadata['height'] = 43;
+              $site_file->metadata['width'] = 161;
+            }
+            if ($site_file) {
+              $banner['image'] = array(
+                'path' => $site_file->uri,
+                'width' => !empty($site_file->metadata['width']) ? $site_file->metadata['width'] : 0,
+                'height' => !empty($site_file->metadata['height']) ? $site_file->metadata['height'] : 0,
+                'alt' => t('Site banner'),
+                'attributes' => array(
+                  'class' => $site_stretch ? 'oa-banner-overlay-img' : 'oa-banner-img',
+                ),
+              );
+              $banner['stretch'] = $site_stretch;
+            }
+
+            // Get the site-wide text.
+            $banner['text'] = variable_get('oa_banner_sitename', TRUE) ? variable_get('site_name', '') : '';
+            $banner['slogan'] = variable_get('oa_banner_siteslogan', FALSE) ? variable_get('site_slogan', '') : '';
+          }
+        }
+      }
+
+      // Store in the cache for later.
+      $static_cache[$static_cache_key] = $banner;
+      cache_set($cid, $banner);
+    }
+  }
+
+  return $static_cache[$static_cache_key];
 }

--- a/modules/oa_appearance/oa_appearance.module
+++ b/modules/oa_appearance/oa_appearance.module
@@ -339,7 +339,7 @@ function oa_appearance_get_space_banner($space_id, $banner_position) {
       // Get the Space's 'Banner position'. If it's set to '- None -', then we
       // take the site's 'Banner position' - which is different than 'Hidden',
       // ie. a position of 0.
-      $space_position = field_get_items('node', $space, OA_SPACE_BANNER_POSITION);
+      $space_position = !empty($space) ? field_get_items('node', $space, OA_SPACE_BANNER_POSITION) : array();
       $space_position = isset($space_position[0]['value']) ? $space_position[0]['value'] : $site_position;
 
       // Only attempt to figure out the banner settings if the Space's
@@ -347,7 +347,7 @@ function oa_appearance_get_space_banner($space_id, $banner_position) {
       if ($space_position != 0) {
         // First, check if the Space is overriding the banner image. If so, we
         // use its banner settings.
-        $space_image = field_get_items('node', $space, 'field_oa_banner');
+        $space_image = !empty($space) ? field_get_items('node', $space, 'field_oa_banner') : array();
         $space_image = !empty($space_image) ? $space_image[0] : NULL;
         if ($space_image && $space_position == $banner_position) {
           $banner['position'] = $space_position;
@@ -370,8 +370,8 @@ function oa_appearance_get_space_banner($space_id, $banner_position) {
         // If the Space doesn't override, then pull the parent's settings. If
         // there is no parent, then these are the site-wide settings.
         else {
-          $parent = module_exists('oa_subspaces') ? field_get_items('node', $space, OA_PARENT_SPACE) : NULL;
-          $parent = !empty($parent[0]['target_id']) ? node_load($parent[0]['target_id']) : NULL;
+          $parent_nids = oa_core_get_parents($space_id);
+          $parent = !empty($parent_nids[0]) ? node_load($parent_nids[0]) : NULL;
           if ($parent && $parent->type == 'oa_space') {
             $banner = oa_appearance_get_space_banner($parent->nid, $banner_position);
           }
@@ -453,8 +453,8 @@ function oa_appearance_get_space_colorizer_instance($base_instance, $space_id) {
 
       // If there is no instance for the current Space, then try it's parent.
       if ($space && variable_get("colorizer_{$instance}_palette", FALSE) === FALSE && module_exists('oa_subspaces')) {
-        $parent = field_get_items('node', $space, OA_PARENT_SPACE);
-        $parent = !empty($parent[0]['target_id']) ? node_load($parent[0]['target_id']) : NULL;
+        $parent_nids = oa_core_get_parents($space_id);
+        $parent = !empty($parent_nids[0]) ? node_load($parent_nids[0]) : NULL;
         if ($parent && $parent->type == 'oa_space') {
           $instance = oa_appearance_get_space_colorizer_instance($base_instance, $parent->nid);
         }

--- a/modules/oa_appearance/plugins/content_types/oa_space_banner.inc
+++ b/modules/oa_appearance/plugins/content_types/oa_space_banner.inc
@@ -27,40 +27,8 @@ function oa_space_banner_render($subtype, $conf, $args, $context = NULL) {
   $space_id = oa_core_get_space_home_context();
   $position = isset($conf['banner_position']) ? $conf['banner_position'] : OA_SPACE_BANNER_BELOW;
 
-  $site_banner_position = variable_get('oa_site_banner_position', 0);
-  $show_site = ($site_banner_position == $conf['banner_position']);
-
-  if (($space = node_load(oa_core_get_group_from_node($space_id))) && node_access('view', $space)) {
-    $field = field_get_items('node', $space, OA_SPACE_BANNER_POSITION);
-  }
-  $show_space = (!empty($field[0]['value']) && ($field[0]['value'] == $conf['banner_position']));
-  if ($show_space) {
-    $space_picture = field_get_items('node', $space, 'field_oa_banner');
-    if (!empty($space_picture)) {
-      $space_picture = array_shift($space_picture);
-    }
-    else {
-      $show_space = FALSE;
-    }
-  }
-  if ($show_site) {
-    $fid = variable_get('oa_site_banner', '');
-    if ($fid && ($site_file = file_load($fid))) {
-      // successful banner loaded
-    }
-    elseif (variable_get('oa_banner_default', TRUE)) {
-      // use default banner image
-      $site_file = new stdClass();
-      $path = drupal_get_path('module', 'oa_widgets');
-      $site_file->uri = $base_url . '/' . $path . '/openatrium-powered.png';
-      $site_file->metadata['height'] = 43;
-      $site_file->metadata['width'] = 161;
-    }
-    else {
-      $show_site = FALSE;
-    }
-  }
-  if (!$show_site && !$show_space) {
+  $banner = oa_appearance_get_space_banner(oa_core_get_group_from_node($space_id), $position);
+  if ($banner['position'] == 0) {
     return;
   }
 
@@ -68,59 +36,19 @@ function oa_space_banner_render($subtype, $conf, $args, $context = NULL) {
 
   $vars = array();
 
-  $vars['banner'] = '';
-  $vars['text'] = '';
-  $vars['slogan'] = '';
-  $vars['height'] = '';
-  $vars['width'] = '';
+  $vars['banner_class'] = ($position == 1) ? 'oa-banner-before' : 'oa-banner-after';
+  $vars['banner'] = !empty($banner['image']) ? theme('image', $banner['image']) : '';
+  $vars['width'] = isset($banner['image']['width']) ? $banner['image']['width'] : 0;
+  $vars['height'] = isset($banner['image']['height']) ? $banner['image']['height'] : 0;
+  $vars['text'] = $banner['text'];
+  $vars['slogan'] = $banner['slogan'];
   $vars['banner_text_class'] = 'oa-banner-overlay';
   $vars['banner_slogan_class'] = 'oa-banner-slogan-overlay';
-  $vars['banner_class'] = ($conf['banner_position'] == 1) ? 'oa-banner-before' : 'oa-banner-after';
+  if (!empty($banner['image']) && !$banner['stretch']) {
+    $vars['banner_text_class'] = 'oa-banner-text';
+    $vars['banner_slogan_class'] = 'oa-banner-slogan';
+  }
 
-  if ($show_space) {
-    $vars['height'] = $space_picture['height'];
-    $vars['width'] = $space_picture['width'];
-    $vars['banner'] = theme('image', array(
-      'path' => $space_picture['uri'],
-      'width' => $space_picture['width'],
-      'height' => $space_picture['height'],
-      'alt' => $space_picture['alt'],
-      'attributes' => array(
-        'class' => 'oa-banner-overlay-img'
-      ),
-    ));
-    $field = field_view_field('node', $space, 'field_oa_banner_text', array('label' => 'hidden'));
-    if (!empty($field)) {
-      $vars['text'] = drupal_render($field);
-    }
-  }
-  elseif ($show_site) {
-    $vars['height'] = (!empty($site_file->metadata['height'])) ? $site_file->metadata['height'] : 0;
-    $vars['width'] = (!empty($site_file->metadata['width'])) ? $site_file->metadata['width'] : 0;
-    $stretch = variable_get('oa_banner_stretch', FALSE);
-    $vars['banner'] = theme('image', array(
-      'path' => $site_file->uri,
-      'width' => $vars['width'],
-      'height' => $vars['height'],
-      'alt' => t('Site banner'),
-      'attributes' => array(
-        'class' => ($stretch) ? 'oa-banner-overlay-img' : 'oa-banner-img',
-      ),
-    ));
-    $vars['width'] = ($stretch) ? $vars['width'] : 0;
-    $use_sitename = variable_get('oa_banner_sitename', TRUE);
-    if ($use_sitename) {
-      $vars['text'] = variable_get('site_name', '');
-    }
-    $use_siteslogan = variable_get('oa_banner_siteslogan', FALSE);
-    if ($use_siteslogan) {
-      $vars['slogan'] = variable_get('site_slogan', '');
-    }
-    if (!$stretch) {
-      $vars['banner_text_class'] = 'oa-banner-text';
-      $vars['banner_slogan_class'] = 'oa-banner-slogan';
-    }
-  }
   $block = new stdClass();
   $block->title = '';
   $block->content = theme('oa_space_banner', $vars);


### PR DESCRIPTION
This patch allows sub-Spaces to inherit banner and colorizer settings from parent Spaces when not overridden.

Notes:
- I'm using pretty aggressive caching to keep the resulting values. This means that it should only have to walk the tree of parent Spaces the first time the Space is viewed; otherwise it's a single SELECT from the cache table. Caches for children Spaces are cleared when the parent is updated.
- The code for figuring out banner settings was refactored _really heavily_ and will need lots of testing to make sure everything still works the same. But, hopefully, the new version is easier to read and understand.
- Testing that the colorizer inheritence works is annoying, because when you switch to the parent to change it's colors (to see that they change in the child too), you will be changing the OG context to the parent. So, if you switch tabs back to the child, when you reload you'll get the parent colors. But if you navigate to the main child Space page, you'll get the child colors again.
- Selecting "Reset colors to default" will take the Space back to the parent Space's colors, rather than the theme defaults (unless it's a top-level Space).

Please let me know what you think!
