### PR TITLE
Add the new/updated content marker to all the views where it makes sense

### DIFF
--- a/modules/oa_news/oa_news.views_default.inc
+++ b/modules/oa_news/oa_news.views_default.inc
@@ -50,6 +50,14 @@ function oa_news_views_default_views() {
   $handler->display->display_options['fields']['title']['element_type'] = 'h3';
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
+  /* Field: Content: Has new content */
+  $handler->display->display_options['fields']['timestamp']['id'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['table'] = 'history';
+  $handler->display->display_options['fields']['timestamp']['field'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['label'] = '';
+  $handler->display->display_options['fields']['timestamp']['alter']['text'] = 'aoeu';
+  $handler->display->display_options['fields']['timestamp']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['timestamp']['element_default_classes'] = FALSE;
   /* Field: Content: Post date */
   $handler->display->display_options['fields']['created']['id'] = 'created';
   $handler->display->display_options['fields']['created']['table'] = 'node';
@@ -60,7 +68,7 @@ function oa_news_views_default_views() {
   $handler->display->display_options['fields']['created']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['created']['date_format'] = 'panopoly_day';
   $handler->display->display_options['fields']['created']['oa_date'] = '0';
-  /* Field: Content: Body */
+  /* Field: Content: Description */
   $handler->display->display_options['fields']['body']['id'] = 'body';
   $handler->display->display_options['fields']['body']['table'] = 'field_data_body';
   $handler->display->display_options['fields']['body']['field'] = 'body';

--- a/modules/oa_news/templates/views-view-fields--open-atrium-news--oa-recent-news.tpl.php
+++ b/modules/oa_news/templates/views-view-fields--open-atrium-news--oa-recent-news.tpl.php
@@ -32,6 +32,11 @@
   <?php endif; ?>
   <div class='oa-news-header'>
     <?php print $title; ?>
+    <?php if (!empty($timestamp)): ?>
+      <span class='pull-right'>
+        <?php print $timestamp; ?>
+      </span>
+    <?php endif; ?>
     <div class='oa-news-posted'>
       <?php print t('Posted by ') . $name . t(' on ') . $created; ?>
     </div>

--- a/oa_core.views_default.inc
+++ b/oa_core.views_default.inc
@@ -128,6 +128,12 @@ function oa_core_views_default_views() {
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  /* Field: Content: Has new content */
+  $handler->display->display_options['fields']['timestamp']['id'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['table'] = 'history';
+  $handler->display->display_options['fields']['timestamp']['field'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['label'] = '';
+  $handler->display->display_options['fields']['timestamp']['element_label_colon'] = FALSE;
   /* Field: Updated date */
   $handler->display->display_options['fields']['changed']['id'] = 'changed';
   $handler->display->display_options['fields']['changed']['table'] = 'node';
@@ -277,6 +283,7 @@ function oa_core_views_default_views() {
   $handler->display->display_options['style_plugin'] = 'table';
   $handler->display->display_options['style_options']['columns'] = array(
     'title' => 'title',
+    'timestamp' => 'title',
     'changed' => 'changed',
     'body' => 'body',
   );
@@ -285,6 +292,11 @@ function oa_core_views_default_views() {
     'title' => array(
       'sortable' => 1,
       'default_sort_order' => 'asc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'timestamp' => array(
       'align' => '',
       'separator' => '',
       'empty_column' => 0,
@@ -338,6 +350,12 @@ function oa_core_views_default_views() {
   $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
   $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
   $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  /* Field: Content: Has new content */
+  $handler->display->display_options['fields']['timestamp']['id'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['table'] = 'history';
+  $handler->display->display_options['fields']['timestamp']['field'] = 'timestamp';
+  $handler->display->display_options['fields']['timestamp']['label'] = '';
+  $handler->display->display_options['fields']['timestamp']['element_label_colon'] = FALSE;
   /* Field: Updated date */
   $handler->display->display_options['fields']['changed']['id'] = 'changed';
   $handler->display->display_options['fields']['changed']['table'] = 'node';


### PR DESCRIPTION
Includes these Views:
- open_atrium_news
- open_atrium_content

On the Views that are Panes, the new field is totally optional. The user can disable it in the Pane settings if they don't want it.

Here are some screenshots:

![selection_041](https://f.cloud.github.com/assets/191561/2472228/cdc5019e-b032-11e3-93c5-385bdd91714f.png)

![selection_042](https://f.cloud.github.com/assets/191561/2472229/d24eb188-b032-11e3-931b-d4de9daace23.png)
