### PR TITLE
[oa_core] This fixes an issue where the taxonomy module is not fully installed before the feeds module calls 'entity_get_info()' in a CTools Plugin.

### DIFF
--- a/oa_core.make
+++ b/oa_core.make
@@ -167,6 +167,7 @@ projects[feeds][subdir] = contrib
 projects[feeds][download][type] = git
 projects[feeds][download][branch] = 7.x-2.x
 projects[feeds][download][revision] = a8468a
+projects[feeds][patch][2223853] = https://drupal.org/files/issues/2223853-fix_installing_taxonomy_module-4.patch
 
 ; SimplePie library used by Feeds
 libraries[simplepie][download][type] = file


### PR DESCRIPTION
Was talking to a friend of mine (travist) and he had a great solution to the problem.

Read more here: https://drupal.org/node/2223853
