### PR TITLE
Update jquery_update to latest dev

### DIFF
--- a/oa_core.make
+++ b/oa_core.make
@@ -226,8 +226,7 @@ projects[jquery_update][version] = 2.x-dev
 projects[jquery_update][subdir] = contrib
 projects[jquery_update][download][type] = git
 projects[jquery_update][download][branch] = 7.x-2.x
-projects[jquery_update][download][revision] = 65eecb0
-projects[jquery_update][patch][1448490] = http://drupal.org/files/jquery_update-fixes-states-js-1448490.patch
+projects[jquery_update][download][revision] = e5ab70
 
 ; Colorizer
 projects[colorizer][version] = 1.0


### PR DESCRIPTION
Updates the jquery_update module to the latest snapshot of dev.

This latest version of jquery_update addresses previous issues with broken form states.
