### PR TITLE
Create wide breakpoint for navbar if one does not exist.

### DIFF
--- a/oa_core.install
+++ b/oa_core.install
@@ -123,3 +123,28 @@ function oa_core_update_7216() {
 function oa_core_update_7217() {
   module_enable(array('conditional_styles'));
 }
+
+/**
+ * Create wide breakpoint for navbar if one does not exist.
+ *
+ * Without this breakpoint, the navbar breaks in IE10+
+ */
+function oa_core_update_7218() {
+  if (module_exists('breakpoints')) {
+    if(!$breakpoint = breakpoints_breakpoint_load('wide', 'navbar', 'module')) {
+      // Add a breakpoint for switching between horizontal and vertical tray
+      // orientation.
+      $breakpoint = new stdClass();
+      $breakpoint->disabled = FALSE;
+      $breakpoint->api_version = 1;
+      $breakpoint->name = 'wide';
+      $breakpoint->breakpoint = 'only screen and (min-width: 50em)';
+      $breakpoint->source = 'navbar';
+      $breakpoint->source_type = 'module';
+      $breakpoint->status = 1;
+      $breakpoint->weight = 0;
+      $breakpoint->multipliers = array();
+      breakpoints_breakpoint_save($breakpoint);
+    }
+  }
+}


### PR DESCRIPTION
On a current project, the breakpoints module wasn't enabled when the navbar module was installed, which prevented the breakpoint from being created. This caused a js error in IE10+ which prevented the navbar from opening. 

**This change will:**
- Create wide breakpoint for navbar if one does not exist.
