### PR TITLE
'An illegal choice has been detected' when filtering for a Section on another Space.

### DIFF
--- a/oa_core.module
+++ b/oa_core.module
@@ -841,6 +841,20 @@ function oa_core_form_views_exposed_form_alter(&$form, $form_state) {
   if (!empty($form['og_group_ref_target_id'])) {
     $form['#after_build'][] = 'oa_core_views_exposed_form_rearrange';
   }
+  // If a Space was chosen, and we have a Section selector - then we need to
+  // change the available options to be the Sections in that Space (rather
+  // than the current Space). This is necessary to make the customizations
+  // work that were done in:
+  //   oa_core_form_views_content_views_panes_content_type_edit_form_alter()
+  // Otherwise you'll get the 'An illegal choice has been detected.' message
+  // when selecting a Section in another Space.
+  if (!empty($form_state['input']['og_group_ref_target_id']) && !empty($form['oa_section_ref_target_id'])) {
+    $sections = array(
+      ''    => t('- Active Section -'),
+      'All' => t('- Any -')
+    ) + oa_core_space_sections($form_state['input']['og_group_ref_target_id']);
+    $form['oa_section_ref_target_id']['#options'] = $sections;
+  }
 }
 
 function oa_core_views_exposed_form_rearrange($form) {


### PR DESCRIPTION
When adding a widget that filters for Space/Section, it does some really cool AJAX stuff when you change the Space, so that the list of Sections is updated to be the Sections from the selected Space. This works great on the pane configuration form and in the preview.

However, if you select a specific Section (ie. not 'All' or 'Active Section') on another Space, when you actually save the widget and panel and reload the page, it'll say 'An illegal choice has been detected' and show no results. (**NOTE: you have to save and reload to see the error, because the preview works fine, including injecting the results to the IPE editted page.**)

Basically, the problem is that `oa_core_form_views_content_views_panes_content_type_edit_form_alter()` does a great job of modifying the pane configuration form, but it's the views exposed form that is actually submitted. And that form limits the Section filter to only Sections in the currently active Space (I think it's `oa_sections_query_entityreference_alter()` that's doing it), so Sections from other Spaces will cause that basic form validation error.

My PR is super simple, it basically alters the Views exposed filter and changes the list of available Section options if you've selected a Space.

Simple steps to reproduce:
1. Create a Space with a News Section and some Document Pages.
2. Create another Space and add a "Recent Content" widget that specifically filters for content from the first Space in its News Section.
3. Be sure to reload the Space dashboard after adding the "Recent Content" widget.
4. Without this patch, you'll see "An illegal choice has been detected" and no content returned. But with this patch, there is no error message, and the widget will show the Document Pages it should.
