### PR TITLE
Allow users to override the path used by the 'more' link on Recent Content widgets.

### DIFF
--- a/oa_core.views_default.inc
+++ b/oa_core.views_default.inc
@@ -262,7 +262,7 @@ function oa_core_views_default_views() {
   $handler->display->display_options['allow']['offset'] = 0;
   $handler->display->display_options['allow']['link_to_view'] = 0;
   $handler->display->display_options['allow']['more_link'] = 'more_link';
-  $handler->display->display_options['allow']['path_override'] = 0;
+  $handler->display->display_options['allow']['path_override'] = 'path_override';
   $handler->display->display_options['allow']['title_override'] = 'title_override';
   $handler->display->display_options['allow']['exposed_form'] = 'exposed_form';
   $handler->display->display_options['allow']['exposed_form_configure'] = 'exposed_form_configure';


### PR DESCRIPTION
Using OA's "Recent Content" widget can get you suprisingly far without having to create a custom widget! We've got requirements a bunch of widgets which are essentially displaying the titles of nodes in a particular  Section - but the client wants the "more" link to go to the Section page, rather than to the /content page, like the Recent Content widget does now.

This PR simply allows the path to be overridden on the Pane settings, which allows us to use the "Recent Content" widget rather than creating a custom one.
