### PR TITLE
Permissions can now set how Group/Team permissions will be combined and set 'All' as the default seperately.

### DIFF
--- a/modules/oa_access/oa_access.module
+++ b/modules/oa_access/oa_access.module
@@ -30,11 +30,26 @@ define('OA_ACCESS_GROUP_PERMISSION', 2);
 define('OA_ACCESS_ALLOW_OPTION_ALL', 4);
 
 /**
- * Permission type -- This permission will be set to 'All' by default.
+ * Permission type -- This permission will be set to 'All' by default for Groups.
  *
  * This implies OA_ACCESS_ALLOW_OPTION_ALL as well.
  */
-define('OA_ACCESS_DEFAULT_OPTION_ALL', 8 | OA_ACCESS_ALLOW_OPTION_ALL);
+define('OA_ACCESS_GROUP_DEFAULT_OPTION_ALL', 8 | OA_ACCESS_ALLOW_OPTION_ALL);
+
+/**
+ * Permission type -- This permission will be set to 'All' by default for Teams.
+ *
+ * This implies OA_ACCESS_ALLOW_OPTION_ALL as well.
+ */
+define('OA_ACCESS_TEAM_DEFAULT_OPTION_ALL', 16 | OA_ACCESS_ALLOW_OPTION_ALL);
+
+/**
+ * Permission type -- This permission will be set to 'All' by default for all.
+ *
+ * This combines OA_ACCESS_GROUP_DEFAULT_OPTION_ALL and
+ * OA_ACCESS_TEAM_DEFAULT_OPTION_ALL.
+ */
+define('OA_ACCESS_DEFAULT_OPTION_ALL', OA_ACCESS_GROUP_DEFAULT_OPTION_ALL | OA_ACCESS_TEAM_DEFAULT_OPTION_ALL);
 
 /**
  * Permission type -- The default permission type.
@@ -46,6 +61,38 @@ define('OA_ACCESS_DEFAULT_OPTION_ALL', 8 | OA_ACCESS_ALLOW_OPTION_ALL);
  * @see oa_workbench_access
  */
 define('OA_ACCESS_DEFAULT_PERMISSION', OA_ACCESS_TEAM_PERMISSION | OA_ACCESS_GROUP_PERMISSION);
+
+/**
+ * Permission combine type -- Union of Group and Team permissions.
+ *
+ * If either the Group or Team grants permission, then the user has this
+ * permission.
+ */
+define('OA_ACCESS_COMBINE_UNION', 1);
+
+/**
+ * Permission combine type -- Intersection of Group and Team permissions.
+ *
+ * Both the Group and Team must grant permission in order for this user to
+ * be granted permission.
+ */
+define('OA_ACCESS_COMBINE_INTERSECTION', 2);
+
+/**
+ * Permission combine type -- Team permissions override.
+ *
+ * If both Group and Team permissions are set, then the Team permissions
+ * override the Group permissions.
+ */
+define('OA_ACCESS_COMBINE_TEAM_OVERRIDE', 3);
+
+/**
+ * Permission combine type -- Team permissions override.
+ *
+ * If both Group and Team permissions are set, then the Group permissions
+ * override the Team permissions.
+ */
+define('OA_ACCESS_COMBINE_GROUP_OVERRIDE', 4);
 
 /**
  * Implements hook_menu().
@@ -163,7 +210,7 @@ function oa_access_node_insert($node) {
     // OA_ACCESS_TEAM_PERMISSION and add the default 'All' option for those
     // new spaces.
     foreach (oa_access_get_permissions() as $name => $perm) {
-      if ($perm['type'] & OA_ACCESS_DEFAULT_OPTION_ALL && $perm['type'] & OA_ACCESS_TEAM_PERMISSION) {
+      if ($perm['type'] & OA_ACCESS_TEAM_PERMISSION && ($perm['type'] & OA_ACCESS_TEAM_DEFAULT_OPTION_ALL) == OA_ACCESS_TEAM_DEFAULT_OPTION_ALL) {
         oa_access_initialize_permissions(array($name => $perm), array($node->nid));
       }
     }
@@ -183,8 +230,9 @@ function oa_access_node_delete($node) {
  * Implements hook_modules_installed().
  *
  * Check each new module enabled to see if it defines some oa_access_permisions
- * and if they are type OA_ACCESS_DEFAULT_OPTION_ALL, then we set the 'All'
- * permission for all existing Groups and Teams.
+ * and if they are type OA_ACCESS_GROUP_DEFAULT_OPTION_ALL or
+ * OA_ACCESS_TEAM_DEFAULT_OPTION_ALL, then we set the 'All' permission for all
+ * existing Groups and Teams.
  */
 function oa_access_modules_installed($modules) {
   $permission_modules = array();
@@ -244,11 +292,18 @@ function oa_access_get_permissions($reset = FALSE) {
           $perms[$key] = array_merge($perm, array(
             'module' => $module,
           ));
+
+          // Set the default 'type' if not set.
           if (empty($perms[$key]['type'])) {
             $perms[$key]['type'] = OA_ACCESS_DEFAULT_PERMISSION;
           }
           elseif (!($perms[$key]['type'] & OA_ACCESS_GROUP_PERMISSION) && !($perms[$key]['type'] & OA_ACCESS_TEAM_PERMISSION)) {
             $perms[$key]['type'] |= OA_ACCESS_DEFAULT_PERMISSION;
+          }
+
+          // Set the default 'combine' if not set.
+          if (empty($perms[$key]['combine'])) {
+            $perms[$key]['combine'] = OA_ACCESS_COMBINE_UNION;
           }
         }
       }
@@ -260,22 +315,16 @@ function oa_access_get_permissions($reset = FALSE) {
 }
 
 /**
- * Get a list of this user's Groups and Teams.
+ * Get a list of this user's Groups.
  * 
  * @param object|NULL $user 
  *   (Optional) The user to get groups for. If NULL, it will find groups for
  *   the currently logged in user.
- * @param integer $space_nid 
- *   (Optional) The nid of a Space. If given, this will include the Teams
- *   from the given Space. If not given, then Teams won't be included.
  *
  * @return array
- *   An associative array keyed by group nid containing associative arrays with
- *   the following keys:
- *   - nid: The group nid.
- *   - type: The node type (ex: oa_group, oa_team).
+ *   An array of Group nids.
  */
-function oa_access_user_groups($account = NULL, $space_nid = 0) {
+function oa_access_user_groups($account = NULL) {
   global $user;
 
   if (is_null($account)) {
@@ -284,8 +333,8 @@ function oa_access_user_groups($account = NULL, $space_nid = 0) {
 
   $cache =& drupal_static(__FUNCTION__, array());
 
-  if (!isset($cache[$space_nid][$account->uid])) {
-    if (!isset($cache[0][$account->uid])) {
+  if (!isset($cache[$account->uid])) {
+    if (!isset($cache[$account->uid])) {
       // First, get all the users oa_groups.
       $query = db_select('og_membership', 'og');
       $query->innerJoin('node', 'n', 'og.gid = n.nid');
@@ -299,55 +348,71 @@ function oa_access_user_groups($account = NULL, $space_nid = 0) {
 
       $groups = array();
       foreach ($query->execute() as $row) {
-        $groups[$row->nid] = array(
-          'nid'  => $row->nid,
-          'type' => $row->type,
-        );
+        $groups[$row->nid] = $row->nid;
       }
 
       // All users are members of the magic 'All' group with an NID of 0.
-      $groups[0] = array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      );
+      $groups[0] = 0;
 
-      $cache[0][$account->uid] = $groups;
+      $cache[$account->uid] = $groups;
+    }
+  }
+
+  return $cache[$account->uid];
+}
+
+/**
+ * Get a list of this user's Teams.
+ * 
+ * @param object|NULL $user 
+ *   (Optional) The user to get groups for. If NULL, it will find groups for
+ *   the currently logged in user.
+ * @param integer $space_nid 
+ *   (Optional) The nid of a Space. If given, this will include the Teams
+ *   from the given Space. If not given, then Teams won't be included.
+ *
+ * @return array
+ *   An array of Team nids.
+ */
+function oa_access_user_teams($space_nid, $account = NULL) {
+  global $user;
+
+  if (!module_exists('oa_teams')) {
+    return array();
+  }
+
+  if (is_null($account)) {
+    $account = $user;
+  }
+
+  $cache =& drupal_static(__FUNCTION__, array());
+
+  if (!isset($cache[$space_nid][$account->uid])) {
+    $teams = array();
+
+    $valid_teams = oa_teams_get_teams_for_space($space_nid);
+    if (count($valid_teams) > 0) {
+      // Then, we get all the user's oa_teams, optionally filtering by valid
+      // teams for this particular Space.
+      $query = db_select('field_data_' . OA_TEAM_USERS_FIELD, 'f')
+        ->fields('f', array('entity_id'))
+        ->condition('entity_type', 'node')
+        ->condition('entity_id', array_keys($valid_teams), 'IN')
+        ->condition('deleted', 0)
+        ->condition(OA_TEAM_USERS_FIELD . '_target_id', $account->uid);
+
+      foreach ($query->execute() as $row) {
+        $teams[$row->entity_id] = $row->entity_id;
+      }
     }
 
-    if (module_exists('oa_teams') && $space_nid) {
-      $teams = array();
-
-      $valid_teams = oa_teams_get_teams_for_space($space_nid);
-      if (count($valid_teams) > 0) {
-        // Then, we get all the user's oa_teams, optionally filtering by valid
-        // teams for this particular Space.
-        $query = db_select('field_data_' . OA_TEAM_USERS_FIELD, 'f')
-          ->fields('f', array('entity_id'))
-          ->condition('entity_type', 'node')
-          ->condition('entity_id', array_keys($valid_teams), 'IN')
-          ->condition('deleted', 0)
-          ->condition(OA_TEAM_USERS_FIELD . '_target_id', $account->uid);
-
-        foreach ($query->execute() as $row) {
-          $teams[$row->entity_id] = array(
-            'nid' => $row->entity_id,
-            'type' => 'oa_team',
-          );
-        }
-      }
-
-      // All Space members are members of the magic 'All' team with an NID
-      // that is equal to the Space's NID.
-      if (og_is_member('node', $space_nid, 'user', $account)) {
-        $teams[$space_nid] = array(
-          'nid' => $space_nid,
-          'type' => 'oa_team',
-        );
-      }
-
-      // Combine the cached Groups with the Teams to get the full result.
-      $cache[$space_nid][$account->uid] = $cache[0][$account->uid] + $teams;
+    // All Space members are members of the magic 'All' team with an NID
+    // that is equal to the Space's NID.
+    if (og_is_member('node', $space_nid, 'user', $account)) {
+      $teams[$space_nid] = $space_nid;
     }
+
+    $cache[$space_nid][$account->uid] = $teams;
   }
 
   return $cache[$space_nid][$account->uid];
@@ -370,6 +435,8 @@ function oa_access_user_groups($account = NULL, $space_nid = 0) {
  *   a module called 'mymodule'.
  *
  * @see oa_access_set_group_permissions()
+ * @see oa_access_user_groups()
+ * @see oa_access_user_teams()
  */
 function oa_access_get_group_permissions($groups) {
   $cache =& drupal_static(__FUNCTION__, array());
@@ -448,18 +515,22 @@ function oa_access_set_group_permissions($group_permissions) {
 /**
  * Gets a combined list of the permissions that a list of groups can perform.
  *
- * The permissions of all the groups are combined, such that if any group in
- * the list has permission, it will be returned.
+ * This doesn't obey the permissions 'combine' property - it's just a straight
+ * forward union of all the permissions from each Group or Team.
  *
- * @param array $groups
- *   An array of nids of Groups or Teams.
- * 
+ * @param array
+ *   An array of Group or Team nids.
+ *
  * @return array
  *   @code
  *   array('one permission' => TRUE, 'an other permission' => TRUE)
  *   @endcode
  *   Which signifies that the combined permissions of the given groups
  *   include 'one permission' and 'an other permission'.
+ *
+ * @see oa_access_get_group_permissions()
+ * @see oa_access_user_groups()
+ * @see oa_access_user_teams()
  */
 function oa_access_get_group_permissions_combined($groups) {
   $return = array();
@@ -474,12 +545,41 @@ function oa_access_get_group_permissions_combined($groups) {
 }
 
 /**
+ * Helper function to determine if a permission is overridden by Group or Team.
+ *
+ * @param string $perm
+ *   The permission name.
+ * @param integer $space_nid 
+ *   The nid of a Space, when checking if Teams override, or zero if checking
+ *   if the Groups override.
+ */
+function _oa_access_is_overridden($perm, $space_nid) {
+  $groups =& drupal_static(__FUNCTION__, array());
+
+  if (!isset($groups[$space_nid])) {
+    if ($space_nid == 0) {
+      // Get an array of all the Group nids.
+      $groups[$space_nid] = array_keys(oa_core_get_all_groups());
+    }
+    else {
+      // Get an array of all the Team nids.
+      $groups[$space_nid] = array_keys(oa_teams_get_teams_for_space($space_nid));
+    }
+    // Add the magic 'All' option.
+    $groups[$space_nid][] = $space_nid;
+  }
+
+  $permissions = oa_access_get_group_permissions_combined($groups[$space_nid]);
+  return isset($permissions[$perm]);
+}
+
+/**
  * Determines if the user has a permission.
  *
  * This is based on the user's membership in an Open Atrium Group or Team in
  * the same way that user_access() is based on a user's membership in a role.
  *
- * @param object|NULL $space
+ * @param object|integer|NULL $space
  *   The Space in which we want to perform the action. You can pass NULL if
  *   there is no Space active (this will mean that Team permissions won't be
  *   considered).
@@ -516,20 +616,51 @@ function oa_access($space, $permission, $account = NULL) {
   //
   $cache =& drupal_static(__FUNCTION__, array());
 
-  $space_nid = !module_exists('oa_teams') ? 0 : ($space ? $space->nid : 0);
+  $space = !module_exists('oa_teams') ? 0 : ($space ? $space : 0);
+  $space_nid = is_object($space) ? $space->nid : $space;
 
   if (!isset($cache[$space_nid][$account->uid])) {
-    $groups = oa_access_user_groups($account, $space_nid);
-    // If we have Team permissions, then we don't take the 'all group' into
-    // account - it's overridden by whatever the Team permissions are.
-    if ($space_nid != 0) {
-      unset($groups[0]);
+    // Get the Group and Team permissions.
+    $group_permissions = oa_access_get_group_permissions_combined(oa_access_user_groups($account));
+    $team_permissions = $space_nid ? oa_access_get_group_permissions_combined(oa_access_user_teams($space_nid, $account)) : array();
+
+    // Loop over the permissions, combining the Group and Team grants per the
+    // 'combine' property on the permission.
+    $perms = array();
+    foreach (oa_access_get_permissions() as $perm => $info) {
+      switch ($info['combine']) {
+        case OA_ACCESS_COMBINE_UNION:
+          $perms[$perm] = isset($group_permissions[$perm]) || isset($team_permissions[$perm]);
+          break;
+
+        case OA_ACCESS_COMBINE_INTERSECTION:
+          $perms[$perm] = isset($group_permissions[$perm]) && isset($team_permissions[$perm]);
+          break;
+
+        case OA_ACCESS_COMBINE_TEAM_OVERRIDE:
+          if ($space_nid && _oa_access_is_overridden($perm, $space_nid)) {
+            $perms[$perm] = isset($team_permissions[$perm]);
+          }
+          else {
+            $perms[$perm] = isset($group_permissions[$perm]) || isset($team_permissions[$perm]);
+          }
+          break;
+
+        case OA_ACCESS_COMBINE_GROUP_OVERRIDE:
+          if (_oa_access_is_overridden($perm, 0)) {
+            $perms[$perm] = isset($group_permissions[$perm]);
+          }
+          else {
+            $perms[$perm] = isset($group_permissions[$perm]) || isset($team_permissions[$perm]);
+          }
+          break;
+      }
     }
-    $perms = oa_access_get_group_permissions_combined(array_keys($groups));
+
     $cache[$space_nid][$account->uid] = $perms;
   }
 
-  return isset($cache[$space_nid][$account->uid][$permission]);
+  return $cache[$space_nid][$account->uid][$permission];
 }
 
 /**
@@ -544,8 +675,9 @@ function oa_access($space, $permission, $account = NULL) {
  * the number of repeated database queries.
  *
  * At the moment, all this does is set the default permissions for permissions
- * with a type of OA_ACCESS_DEFAULT_OPTION_ALL. If you don't have any with that
- * type you don't have to ever call this function.
+ * with a type of OA_ACCESS_GROUP_DEFAULT_OPTION_ALL or
+ * OA_ACCESS_TEAM_DEFAULT_OPTION_ALL. If you don't have any with those types,
+ * you don't have to ever call this function.
  *
  * @param string|object $perms
  *   The machine name of the new permission or an associative array containing
@@ -575,16 +707,16 @@ function oa_access_initialize_permissions($perms, array $groups = array()) {
   $updated = FALSE;
 
   foreach ($perms as $name => $perm) {
-    if ($perm['type'] & OA_ACCESS_DEFAULT_OPTION_ALL) {
-      $nids = array();
-      if ($perm['type'] & OA_ACCESS_TEAM_PERMISSION) {
-        $nids = $groups;
-      }
-      if ($perm['type'] & OA_ACCESS_GROUP_PERMISSION) {
-        // Add the '0' nid for the 'All' group.
-        $nids[] = 0;
-      }
+    $nids = array();
+    if ($perm['type'] & OA_ACCESS_TEAM_PERMISSION && ($perm['type'] & OA_ACCESS_TEAM_DEFAULT_OPTION_ALL) == OA_ACCESS_TEAM_DEFAULT_OPTION_ALL) {
+      $nids = $groups;
+    }
+    if ($perm['type'] & OA_ACCESS_GROUP_PERMISSION && ($perm['type'] & OA_ACCESS_GROUP_DEFAULT_OPTION_ALL) == OA_ACCESS_GROUP_DEFAULT_OPTION_ALL) {
+      // Add the '0' nid for the 'All' group.
+      $nids[] = 0;
+    }
 
+    if (count($nids) > 0) {
       foreach ($nids as $nid) {
         db_merge('oa_access')
           ->key(array(

--- a/modules/oa_access/tests/oa_access.test
+++ b/modules/oa_access/tests/oa_access.test
@@ -257,41 +257,99 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
         'description' => t('Gives you the ability to access Open Atrium Access Test'),
         'module' => 'oa_access_test',
         'type' => OA_ACCESS_DEFAULT_PERMISSION,
+        'combine' => OA_ACCESS_COMBINE_UNION,
       ),
       'administer oa_access_test' => array(
         'title' => t('Administer Open Atrium Access Test'),
         'description' => t('Gives you the ability to administer Open Atrium Access Test'),
         'module' => 'oa_access_test',
         'type' => OA_ACCESS_DEFAULT_PERMISSION,
+        'combine' => OA_ACCESS_COMBINE_UNION,
       ),
       'group permission for oa_access_test' => array(
         'title' => t('A Group-only permission for Open Atrium Access Test'),
         'description' => t('Used to test Group-only permissions'),
-        'module' => 'oa_access_test',
         'type' => OA_ACCESS_GROUP_PERMISSION,
+        'module' => 'oa_access_test',
+        'combine' => OA_ACCESS_COMBINE_UNION,
       ),
       'team permission for oa_access_test' => array(
         'title' => t('A Team-only permission for Open Atrium Access Test'),
         'description' => t('Used to test Team-only permissions'),
-        'module' => 'oa_access_test',
         'type' => OA_ACCESS_TEAM_PERMISSION,
+        'module' => 'oa_access_test',
+        'combine' => OA_ACCESS_COMBINE_UNION,
       ),
       'permission with all option for oa_access_test' => array(
         'title' => t('A permission with an "All" option'),
         'description' => t('Used to test the "All" option'),
-        'module' => 'oa_access_test',
         'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+        'module' => 'oa_access_test',
+        'combine' => OA_ACCESS_COMBINE_UNION,
+      ),
+      'access oa_access_test intersection' => array(
+        'title' => t('Access Open Atrium Access Test (Intersection)'),
+        'description' => t('Tests OA_ACCESS_COMBINE_INTERSECTION.'),
+        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+        'combine' => OA_ACCESS_COMBINE_INTERSECTION,
+        'module' => 'oa_access_test',
+      ),
+      'access oa_access_test team override' => array(
+        'title' => t('Access Open Atrium Access Test (Team Override)'),
+        'description' => t('Tests OA_ACCESS_COMBINE_TEAM_OVERRIDE.'),
+        'combine' => OA_ACCESS_COMBINE_TEAM_OVERRIDE,
+        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+        'module' => 'oa_access_test',
+      ),
+      'access oa_access_test group override' => array(
+        'title' => t('Access Open Atrium Access Test (Group Override)'),
+        'description' => t('Tests OA_ACCESS_COMBINE_GROUP_OVERRIDE.'),
+        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+        'combine' => OA_ACCESS_COMBINE_GROUP_OVERRIDE,
+        'module' => 'oa_access_test',
       ),
       'a permission for oa_access_test that is only conditionally available' => array(
         'title' => t('Some fickle permission'),
         'description' => t('A permission for oa_access_test that is only conditionally available'),
         'module' => 'oa_access_test',
         'type' => OA_ACCESS_DEFAULT_PERMISSION,
+        'combine' => OA_ACCESS_COMBINE_UNION,
       ),
     ));
   }
 
   public function testUserGroups() {
+    // Create an admin user and login.
+    $account = $this->oaCreateUser(array('create oa_space content'));
+    $this->drupalLogin($account);
+
+    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'));
+    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'));
+
+    // Add the user from $group_a to $group_b as well.
+    og_group('node', $group_b['group']->nid, array(
+      'entity type' => 'user',
+      'entity' => $group_a['user']->uid,
+      'membership type' => OG_MEMBERSHIP_TYPE_DEFAULT,
+    ));
+
+    // Check the groups that the $group_a user belongs to.
+    $this->assertEqual(oa_access_user_groups($group_a['user']), array(
+      $group_a['group']->nid => $group_a['group']->nid,
+      $group_b['group']->nid => $group_b['group']->nid,
+      // Magic 'All' Group.
+      0 => 0,
+    ));
+
+    // Check the (much simpler) $group_b user.
+    $this->assertEqual(oa_access_user_groups($group_b['user']), array(
+      $group_b['group']->nid => $group_b['group']->nid,
+      // Magic 'All' Group.
+      0 => 0,
+    ));
+  }
+
+  public function testUserTeams() {
     // Create an admin user and login.
     $account = $this->oaCreateUser(array('create oa_space content'));
     $this->drupalLogin($account);
@@ -303,115 +361,21 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
       'uid'   => $account->uid,
     ));
 
-    $group_a = $this->oaCreateGroupWithUser(array('title' => 'Group A'), array('access content'), $space1);
-    $group_b = $this->oaCreateGroupWithUser(array('title' => 'Group B'), array('access content'), $space1);
+    $user_a = $this->oaCreateUser(array(), $space1);
 
-    // Add the user from $group_a to $group_b as well.
-    og_group('node', $group_b['group']->nid, array(
-      'entity type' => 'user',
-      'entity' => $group_a['user']->uid,
-      'membership type' => OG_MEMBERSHIP_TYPE_DEFAULT,
-    ));
-
-    // Now, create a Team in our Space and additionally add the user from
-    // $group_a to it.
+    // Now, create a Team in our Space.
     $team_a = $this->oaCreateTeamWithUser(array('title' => 'Team A'), array('access content'), $space1);
-    oa_teams_add_member($team_a['team'], $group_a['user']->uid);
 
-    // Check the groups that the $group_a user belongs too (both including and
-    // excluding Teams).
-    $this->assertEqual(oa_access_user_groups($group_a['user']), array(
-      $group_a['group']->nid => array(
-        'nid' => $group_a['group']->nid,
-        'type' => 'oa_group',
-      ),
-      $group_b['group']->nid => array(
-        'nid' => $group_b['group']->nid,
-        'type' => 'oa_group',
-      ),
-      // Magic 'All' Group.
-      0 => array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      ),
-    ));
-    $this->assertEqual(oa_access_user_groups($group_a['user'], $space1->nid), array(
-      $group_a['group']->nid => array(
-        'nid' => $group_a['group']->nid,
-        'type' => 'oa_group',
-      ),
-      $group_b['group']->nid => array(
-        'nid' => $group_b['group']->nid,
-        'type' => 'oa_group',
-      ),
-      $team_a['team']->nid => array(
-        'nid' => $team_a['team']->nid,
-        'type' => 'oa_team',
-      ),
-      // Magic 'All' Group.
-      0 => array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      ),
-      // Magic 'All' Team.
-      $space1->nid => array(
-        'nid' => $space1->nid,
-        'type' => 'oa_team',
-      ),
+    // Check the teams that the $team_a user belongs to.
+    $this->assertEqual(oa_access_user_teams($space1->nid, $team_a['user']), array(
+      $team_a['team']->nid => $team_a['team']->nid,
+      $space1->nid => $space1->nid,
     ));
 
-    // Check the (much simpler) $group_b user.
-    $this->assertEqual(oa_access_user_groups($group_b['user']), array(
-      $group_b['group']->nid => array(
-        'nid' => $group_b['group']->nid,
-        'type' => 'oa_group',
-      ),
-      // Magic 'All' Group.
-      0 => array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      ),
-    ));
-    $this->assertEqual(oa_access_user_groups($group_b['user'], $space1->nid), array(
-      $group_b['group']->nid => array(
-        'nid' => $group_b['group']->nid,
-        'type' => 'oa_group',
-      ),
-      // Magic 'All' Group.
-      0 => array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      ),
+    // Check the (much simpler) $user_a user.
+    $this->assertEqual(oa_access_user_teams($space1->nid, $user_a), array(
       // Magic 'All' Team.
-      $space1->nid => array(
-        'nid' => $space1->nid,
-        'type' => 'oa_team',
-      ),
-    ));
-
-    // And finally the $team_a user.
-    $this->assertEqual(oa_access_user_groups($team_a['user']), array(
-      // Magic 'All' Group.
-      0 => array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      ),
-    ));
-    $this->assertEqual(oa_access_user_groups($team_a['user'], $space1->nid), array(
-      $team_a['team']->nid => array(
-        'nid' => $team_a['team']->nid,
-        'type' => 'oa_team',
-      ),
-      // Magic 'All' Group.
-      0 => array(
-        'nid' => 0,
-        'type' => 'oa_group',
-      ),
-      // Magic 'All' Team.
-      $space1->nid => array(
-        'nid' => $space1->nid,
-        'type' => 'oa_team',
-      ),
+      $space1->nid => $space1->nid,
     ));
   }
 
@@ -590,7 +554,7 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
     $this->assertTrue(oa_access($space1, 'permission with all option for oa_access_test', $team_b['user']));
   }
 
-  public function testTeamWithAllGroupAccess() {
+  public function testTeamOverride() {
     // Create an admin user and login.
     $account = $this->oaCreateUser(array('create oa_space content'));
     $this->drupalLogin($account);
@@ -610,10 +574,10 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
       // Say (via Groups permissions) that 'All site users' have access to this
       // permission.
       0 => array(
-        'oa_access_test' => array('permission with all option for oa_access_test'),
+        'oa_access_test' => array('access oa_access_test team override'),
       ),
       $team_a['team']->nid => array(
-        'oa_access_test' => array('permission with all option for oa_access_test'),
+        'oa_access_test' => array('access oa_access_test team override'),
       ),
     );
     oa_access_set_group_permissions($group_permissions);
@@ -621,15 +585,15 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
     // So, in this case, only members of $team_a should have this permission
     // even though 'All site users' have it, the Team permissions have further
     // reduced access.
-    $this->assertTrue(oa_access($space1, 'permission with all option for oa_access_test', $team_a['user']));
-    $this->assertFalse(oa_access($space1, 'permission with all option for oa_access_test', $not_in_team));
-    $this->assertFalse(oa_access($space1, 'permission with all option for oa_access_test', $not_in_space));
+    $this->assertTrue(oa_access($space1, 'access oa_access_test team override', $team_a['user']));
+    $this->assertFalse(oa_access($space1, 'access oa_access_test team override', $not_in_team));
+    $this->assertFalse(oa_access($space1, 'access oa_access_test team override', $not_in_space));
 
     // However, if we are operating outside of a Space context, then all users
     // should get it, ie. there are no Teams to restrict access further.
-    $this->assertTrue(oa_access(NULL, 'permission with all option for oa_access_test', $team_a['user']));
-    $this->assertTrue(oa_access(NULL, 'permission with all option for oa_access_test', $not_in_team));
-    $this->assertTrue(oa_access(NULL, 'permission with all option for oa_access_test', $not_in_space));
+    $this->assertTrue(oa_access(NULL, 'access oa_access_test team override', $team_a['user']));
+    $this->assertTrue(oa_access(NULL, 'access oa_access_test team override', $not_in_team));
+    $this->assertTrue(oa_access(NULL, 'access oa_access_test team override', $not_in_space));
   }
 
   public function testGroupAdminPage() {
@@ -796,7 +760,7 @@ class OpenAtriumAccessAllTestCase extends OpenAtriumAccessBaseTestCase {
       'permission that defaults to all for oa_access_test_all' => array(
         'title' => t('A permission that defaults to the "All" option'),
         'description' => t('Used to test the functionality to default to the "All" option'),
-        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_DEFAULT_OPTION_ALL,
+        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_GROUP_DEFAULT_OPTION_ALL,
         'module' => 'oa_access_test_all',
       ),
     );
@@ -807,7 +771,7 @@ class OpenAtriumAccessAllTestCase extends OpenAtriumAccessBaseTestCase {
     $perms['a permission for oa_access_test_all that is added after install'] = array(
       'title' => t('Some fickle permission'),
       'description' => t('A permission for oa_access_test that is only conditionally available'),
-      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_DEFAULT_OPTION_ALL,
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_GROUP_DEFAULT_OPTION_ALL,
       'module' => 'oa_access_test_all',
     );
     $this->assertEqual(oa_access_get_permissions(TRUE), $perms);

--- a/modules/oa_access/tests/oa_access_test/oa_access_test.module
+++ b/modules/oa_access/tests/oa_access_test/oa_access_test.module
@@ -32,6 +32,24 @@ function oa_access_test_oa_access_permission() {
       'description' => t('Used to test the "All" option'),
       'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
     ),
+    'access oa_access_test intersection' => array(
+      'title' => t('Access Open Atrium Access Test (Intersection)'),
+      'description' => t('Tests OA_ACCESS_COMBINE_INTERSECTION.'),
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+      'combine' => OA_ACCESS_COMBINE_INTERSECTION,
+    ),
+    'access oa_access_test team override' => array(
+      'title' => t('Access Open Atrium Access Test (Team Override)'),
+      'description' => t('Tests OA_ACCESS_COMBINE_TEAM_OVERRIDE.'),
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+      'combine' => OA_ACCESS_COMBINE_TEAM_OVERRIDE,
+    ),
+    'access oa_access_test group override' => array(
+      'title' => t('Access Open Atrium Access Test (Group Override)'),
+      'description' => t('Tests OA_ACCESS_COMBINE_GROUP_OVERRIDE.'),
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+      'combine' => OA_ACCESS_COMBINE_GROUP_OVERRIDE,
+    ),
   );
   if (!variable_get('oa_access_test_remove_permission', FALSE)) {
     $permissions['a permission for oa_access_test that is only conditionally available'] = array(

--- a/modules/oa_access/tests/oa_access_test_all/oa_access_test_all.module
+++ b/modules/oa_access/tests/oa_access_test_all/oa_access_test_all.module
@@ -12,14 +12,14 @@ function oa_access_test_all_oa_access_permission() {
     'permission that defaults to all for oa_access_test_all' => array(
       'title' => t('A permission that defaults to the "All" option'),
       'description' => t('Used to test the functionality to default to the "All" option'),
-      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_DEFAULT_OPTION_ALL,
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_GROUP_DEFAULT_OPTION_ALL | OA_ACCESS_TEAM_DEFAULT_OPTION_ALL,
     ),
   );
   if (variable_get('oa_access_test_all_initialize_permissions', FALSE)) {
     $permissions['a permission for oa_access_test_all that is added after install'] = array(
       'title' => t('Some fickle permission'),
       'description' => t('A permission for oa_access_test that is only conditionally available'),
-      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_DEFAULT_OPTION_ALL,
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_GROUP_DEFAULT_OPTION_ALL | OA_ACCESS_TEAM_DEFAULT_OPTION_ALL,
     );
   }
   return $permissions;


### PR DESCRIPTION
This makes the flags I added in my latest commit to oa_workbench_access actually work:

http://cgit.drupalcode.org/oa_workbench/commit/?id=15a3901a71d39a8ccfdbe90f055434d5bd674114

However, I still need to finish updating all the tests for these changes!
