### PR TITLE
Fix the tests and give Space admins permission to change 'Team permissions' by default.

### DIFF
--- a/modules/oa_access/oa_access.install
+++ b/modules/oa_access/oa_access.install
@@ -48,3 +48,23 @@ function oa_access_schema() {
   );
   return $schema;
 }
+
+/**
+ * Implements hook_install().
+ */
+function oa_access_install() {
+  // By default, we want Space admins to be able to administer oa_access.
+  $og_roles = array_flip(og_roles('node', 'oa_space'));
+  $og_admin_rid = $og_roles[OG_ADMINISTRATOR_ROLE];
+  og_role_grant_permissions($og_admin_rid, array('administer oa_access permissions'));
+}
+
+/**
+ * Give Space admins permission to administer oa_access permissions.
+ */
+function oa_access_update_7001() {
+  // By default, we want Space admins to be able to administer oa_access.
+  $og_roles = array_flip(og_roles('node', 'oa_space'));
+  $og_admin_rid = $og_roles[OG_ADMINISTRATOR_ROLE];
+  og_role_grant_permissions($og_admin_rid, array('administer oa_access permissions'));
+}

--- a/modules/oa_access/tests/oa_access.test
+++ b/modules/oa_access/tests/oa_access.test
@@ -15,31 +15,31 @@
 abstract class OpenAtriumAccessBaseTestCase extends SimpleTestCloneTestCase {
   // The 'standard' profile defines an 'administrator' role which conflicts
   // with panopoly_core's 'administrator' role.
+  // TODO: This is ignored by SimpleTestCloneTestCase...
   protected $profile = 'testing';
 
   public function setUp($modules = array()) {
-    parent::setUp(array(
-      // Without oa_sections, we'll get a Table 'field_data_field_oa_user_ref'
-      // doesn't exist error. Although, we don't actually use Sections here. :-)
-      'oa_sections',
-      'oa_teams',
-      'oa_access',
-    ) + $modules);
+    // TODO: This is how it should look for DrupalWebTestCase!
+    //
+    //parent::setUp(array_merge(array(
+    //  // Without oa_sections, we'll get a Table 'field_data_field_oa_user_ref'
+    //  // doesn't exist error. Although, we don't actually use Sections here. :-)
+    //  'oa_sections',
+    //  'oa_teams',
+    //  'oa_access',
+    //), $modules));
+
+    // However, since we're using SimpleTestCloneTestCase, we need to use this
+    // instead.
+    parent::setUp();
+    module_enable($modules);
 
     // Since we're not enabling oa_home, we need to make sure the front page
     // exists, or $this->drupalLogin() will fail from the 404.
     variable_set('site_frontpage', 'user');
 
     // Flush all static caches.
-    $static_caches = array(
-      'oa_access',
-      'oa_access_user_groups',
-      'oa_access_get_group_permissions',
-      'oa_access_get_permissions',
-    );
-    foreach ($static_caches as $static_cache) {
-      drupal_static_reset($static_cache);
-    }
+    drupal_static_reset();
   }
 
   /**
@@ -230,6 +230,76 @@ abstract class OpenAtriumAccessBaseTestCase extends SimpleTestCloneTestCase {
     ));
     return count($results) > 0;
   }
+
+  /**
+   * Get all permissions defined by implementing modules.
+   *
+   * Wraps oa_access_get_permissions(). Since we're using
+   * SimpleTestCloneTestCase, we can't guarantee that only our permissions are
+   * available, so we have to filter out all others.
+   *
+   * @param string $module
+   *   The name of the module whose permissions we want included.
+   * @param boolean $reset
+   *   (Optional) If set to TRUE, it will reset the static cache.
+   *
+   * @return array
+   *   Associative array keyed with the permission name containing associative
+   *   arrays with the following keys:
+   *   - title: Human readable name of the permission.
+   *   - description: Human readable description of the permission.
+   *   - module: The machine name of the module which defines it.
+   *   - type: Flags specifying if can be used for Groups or Teams or both.
+   *
+   * @see oa_access_get_permissions()
+   */
+  protected function getPermissions($module, $reset = FALSE) {
+    $permissions = array();
+    foreach (oa_access_get_permissions($reset) as $name => $info) {
+      if ($info['module'] == $module) {
+        $permissions[$name] = $info;
+      }
+    }
+    return $permissions;
+  }
+
+  /**
+   * Gets all the permissions that a list of groups have.
+   *
+   * Wraps oa_access_get_group_permissions(). Since we're using
+   * SimpleTestCloneTestCase, we can't guarantee that only our permissions are
+   * available, so we have to filter out all others.
+   *
+   * @param string $module
+   *   The name of the module whose permissions we want included.
+   * @param array $groups
+   *   An array of nids of Groups or Teams.
+   *
+   * @return array
+   *   An associative array keyed by group nid containing associative arrays
+   *   keyed by the module and containing an array of permission names, for
+   *   example:
+   *   @code
+   *   array('27' => array('mymodule' => array('a permission')))
+   *   @endcode
+   *   Which signifies that the group with nid 27 has 'a permission' from
+   *   a module called 'mymodule'.
+   *
+   * @see oa_access_get_group_permissions().
+   */
+  protected function getGroupPermissions($module, $groups) {
+    $permissions = array();
+    foreach (oa_access_get_group_permissions($groups) as $gid => $info) {
+      if (empty($permissions[$gid])) {
+        $permissions[$gid] = array();
+      }
+      if (isset($info[$module])) {
+        $permissions[$gid][$module] = $info[$module];
+      }
+    }
+    return $permissions;
+  }
+
 }
 
 /**
@@ -251,7 +321,7 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
   }
 
   public function testGetPermissions() {
-    $this->assertEqual(oa_access_get_permissions(), array(
+    $this->assertEqual($this->getPermissions('oa_access_test'), array(
       'access oa_access_test' => array(
         'title' => t('Access Open Atrium Access Test'),
         'description' => t('Gives you the ability to access Open Atrium Access Test'),
@@ -297,8 +367,8 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
       'access oa_access_test team override' => array(
         'title' => t('Access Open Atrium Access Test (Team Override)'),
         'description' => t('Tests OA_ACCESS_COMBINE_TEAM_OVERRIDE.'),
-        'combine' => OA_ACCESS_COMBINE_TEAM_OVERRIDE,
         'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_ALLOW_OPTION_ALL,
+        'combine' => OA_ACCESS_COMBINE_TEAM_OVERRIDE,
         'module' => 'oa_access_test',
       ),
       'access oa_access_test group override' => array(
@@ -731,10 +801,6 @@ class OpenAtriumAccessTestCase extends OpenAtriumAccessBaseTestCase {
  * Functional tests for permissions that default to 'All' for the Open Atrium Access module.
  */
 class OpenAtriumAccessAllTestCase extends OpenAtriumAccessBaseTestCase {
-  // The 'standard' profile defines an 'administrator' role which conflicts
-  // with panopoly_core's 'administrator' role.
-  protected $profile = 'testing';
-
   public static function getInfo() {
     return array(
       'name' => 'Open Atrium Access (default "All" permissions)',
@@ -745,11 +811,11 @@ class OpenAtriumAccessAllTestCase extends OpenAtriumAccessBaseTestCase {
 
   public function testModuleEnableAndInitialize() {
     // First, make sure we don't have access.
-    $this->assertEqual(oa_access_get_group_permissions(array(0)), array(0 => array()));
+    $this->assertEqual($this->getGroupPermissions('oa_access_test_all', array(0)), array(0 => array()));
 
     // Then we enable the oa_access_test_all module and check again.
     module_enable(array('oa_access_test_all'));
-    $this->assertEqual(oa_access_get_group_permissions(array(0)), array(
+    $this->assertEqual($this->getGroupPermissions('oa_access_test_all', array(0)), array(
       0 => array(
         'oa_access_test_all' => array('permission that defaults to all for oa_access_test_all'),
       ),
@@ -760,25 +826,27 @@ class OpenAtriumAccessAllTestCase extends OpenAtriumAccessBaseTestCase {
       'permission that defaults to all for oa_access_test_all' => array(
         'title' => t('A permission that defaults to the "All" option'),
         'description' => t('Used to test the functionality to default to the "All" option'),
-        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_GROUP_DEFAULT_OPTION_ALL,
+        'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_DEFAULT_OPTION_ALL,
         'module' => 'oa_access_test_all',
+        'combine' => OA_ACCESS_COMBINE_UNION,
       ),
     );
-    $this->assertEqual(oa_access_get_permissions(), $perms);
+    $this->assertEqual($this->getPermissions('oa_access_test_all'), $perms);
 
     // Now, we want to add a new permission and test that it's available.
     variable_set('oa_access_test_all_initialize_permissions', TRUE);
     $perms['a permission for oa_access_test_all that is added after install'] = array(
       'title' => t('Some fickle permission'),
       'description' => t('A permission for oa_access_test that is only conditionally available'),
-      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_GROUP_DEFAULT_OPTION_ALL,
+      'type' => OA_ACCESS_DEFAULT_PERMISSION | OA_ACCESS_DEFAULT_OPTION_ALL,
       'module' => 'oa_access_test_all',
+      'combine' => OA_ACCESS_COMBINE_UNION,
     );
-    $this->assertEqual(oa_access_get_permissions(TRUE), $perms);
+    $this->assertEqual($this->getPermissions('oa_access_test_all', TRUE), $perms);
 
     // Next, we initialize it and check that the 'All' group has it.
     oa_access_initialize_permissions('a permission for oa_access_test_all that is added after install');
-    $this->assertEqual(oa_access_get_group_permissions(array(0)), array(
+    $this->assertEqual($this->getGroupPermissions('oa_access_test_all', array(0)), array(
       0 => array(
         'oa_access_test_all' => array(
           'a permission for oa_access_test_all that is added after install',


### PR DESCRIPTION
Running the tests with drush works for me:

drush test-run 'Open Atrium Access'

There are loads of exceptions and notices, but all the tests appear to pass:

Open Atrium Access (default "All" permissions) 24 passes, 0 fails, 7 exceptions, and 4 debug messages
Open Atrium Access 201 passes, 0 fails, 40 exceptions, and 16 debug messages
