### PR TITLE
Add a 'Visible in other Spaces' field to allow users to show content in multiple Spaces.

### DIFF
--- a/oa_core.features.field_base.inc
+++ b/oa_core.features.field_base.inc
@@ -178,6 +178,54 @@ function oa_core_field_default_field_bases() {
     'type' => 'list_boolean',
   );
 
+  // Exported field_base: 'oa_other_spaces_ref'
+  $field_bases['oa_other_spaces_ref'] = array(
+    'active' => 1,
+    'cardinality' => -1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'oa_other_spaces_ref',
+    'foreign keys' => array(
+      'node' => array(
+        'columns' => array(
+          'target_id' => 'nid',
+        ),
+        'table' => 'node',
+      ),
+    ),
+    'indexes' => array(
+      'target_id' => array(
+        0 => 'target_id',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'entityreference',
+    'settings' => array(
+      'handler' => 'og_subspaces',
+      'handler_settings' => array(
+        'behaviors' => array(
+          'og_behavior' => array(
+            'status' => FALSE,
+          ),
+          'views-select-list' => array(
+            'status' => 1,
+          ),
+        ),
+        'membership_type' => 'og_membership_type_default',
+        'sort' => array(
+          'type' => 'none',
+        ),
+        'target_bundles' => array(
+          'oa_space' => 'oa_space',
+        ),
+      ),
+      'handler_submit' => 'Change handler',
+      'target_type' => 'node',
+    ),
+    'translatable' => 0,
+    'type' => 'entityreference',
+  );
+
   // Exported field_base: 'oa_section_ref'
   $field_bases['oa_section_ref'] = array(
     'active' => 1,

--- a/oa_core.info
+++ b/oa_core.info
@@ -28,6 +28,7 @@ features[field_base][] = field_oa_section_override
 features[field_base][] = field_oa_space_type
 features[field_base][] = group_access
 features[field_base][] = group_group
+features[field_base][] = oa_other_spaces_ref
 features[field_base][] = oa_section_ref
 features[field_base][] = og_group_ref
 features[field_base][] = og_roles_permissions

--- a/oa_core.module
+++ b/oa_core.module
@@ -1223,3 +1223,42 @@ function oa_core_node_delete_redirect($form, &$form_state) {
     $form_state['redirect'] = 'node/' . $id;
   }
 }
+
+/**
+ * Implements hook_views_query_alter().
+ */
+function oa_core_views_query_alter(&$view, &$query) {
+  // We only modify views that have 'og_group_ref_target_id' as an exposed
+  // filter and only when that filter has a value. We are adding support for
+  // the 'Visible in other Spaces' (oa_other_spaces_ref) field.
+  if (!empty($view->exposed_input['og_group_ref_target_id']) && is_numeric($view->exposed_input['og_group_ref_target_id']) && !empty($view->filter['og_group_ref_target_id']->options['exposed'])) {
+    // Ensure that we've joined against 'field_data_oa_other_spaces_ref' table.
+    $join = new views_join();
+    $join->construct('field_data_oa_other_spaces_ref', 'node', 'nid', 'entity_id', array(
+      array('field' => 'entity_type', 'value' => 'node'),
+      array('field' => 'deleted', 'value' => 0, 'numeric' => TRUE),
+    ));
+    $alias = $query->ensure_table('field_data_oa_other_spaces_ref', 'node', $join);
+
+    // Add a new 'where group' which is an OR and move 'og_group_ref_target_id'
+    // to it (and grab it's value).
+    $value = array();
+    $group = $query->set_where_group('OR');
+    foreach ($query->where[1]['conditions'] as $key => $condition) {
+      // If the field is 'og_membership.gid' or an alias for the same column.
+      if ($condition['field'] === 'og_membership.gid' || substr($condition['field'], -19) === '__og_membership.gid') {
+        // Move the condition to our new where group.
+        $query->add_where($group, $condition['field'], $condition['value'], $condition['operator']);
+        $value = $condition['value'];
+        unset($query->where[1]['conditions'][$key]);
+        break;
+      }
+    }
+
+    // Finally, we filter against 'field_data_oa_other_spaces_ref' with the
+    // same value as was given to 'oa_group_ref_target_id'.
+    if (!empty($value)) {
+      $query->add_where($group, "{$alias}.oa_other_spaces_ref_target_id", $value, 'IN');
+    }
+  }
+}


### PR DESCRIPTION
This just creates the field (but doesn't put it on any types) and does the Views query alter magic to make it work. I'll create two other PRs in a moment to:
1. Allow the Views alter stuff in oa_subspaces to continue working.
2. Add the field to Document Pages.
