### PR TITLE
When creating a Comment, set the Message user to the Comment user.

### DIFF
--- a/modules/oa_messages/oa_messages.module
+++ b/modules/oa_messages/oa_messages.module
@@ -269,7 +269,7 @@ function oa_messages_comment_insert($comment) {
     // only create messages for node types we care about
     return;
   }
-  $message = oa_messages_create('oa_comment', $comment->nid, 'node', '', $comment->cid);
+  $message = oa_messages_create('oa_comment', $comment->nid, 'node', '', $comment->cid, $comment->uid);
 }
 
 /**


### PR DESCRIPTION
In the current Git, we aren't explicitly passing the $uid when creating a Message. This causes it to use the current user by default. This works fine most of the time, because the current user when hook_comment_insert() runs is the comment author when posting via a web browser. However, when a comment is imported via oa_mailhandler, the current user is either 'anonymous' (if it's run via cron) or an administrator (if they are running it by hand).

This PR basically just passes the comment author's uid explicitly, fixing the problem!
