### PR TITLE
Fix default tours (several of them don't work, mostly due to changes to Open Atrium)

### DIFF
--- a/modules/oa_tour/oa_tour.module
+++ b/modules/oa_tour/oa_tour.module
@@ -66,10 +66,14 @@ function oa_tour_bootstrap_tour_presave_alter(&$tour, &$vals) {
 
 /**
  * Implements hook_bootstrap_tour_alter().
- * Dig into steps with "firstnode/<nodetype>/<tourname>" paths and alter them so that they either point to the first
- * node of a specific type if one exists, or the node add form of that type if not.
+ *
+ * Dig into steps with special paths and alter them so that they either point
+ * to the first node of a specific type if one exists, or the node add form of
+ * that type if not.
  */
 function oa_tour_bootstrap_tour_alter(&$tour) {
+  global $user;
+
   if (empty($tour) || empty($tour->steps)) {
     return;
   }
@@ -77,26 +81,81 @@ function oa_tour_bootstrap_tour_alter(&$tour) {
     if (empty($step['path'])) {
       continue;
     }
+
     $path_parts = explode('/', $step['path']);
-    if ($path_parts[0] == 'firstnode' && count($path_parts) > 1) {
-      $node_type = $path_parts[1];
-      $nid = db_select('node', 'n')
-        ->fields('n', array('nid'))
-        ->condition('type', $node_type)
-        ->orderBy('nid', 'DESC')
-        ->range(0,1)
-        ->execute()
-        ->fetchField();
+    if (in_array($path_parts[0], array('firstnode', 'mynode')) && count($path_parts) > 1) {
+      // Special step path: firstnode/<node_type>/<node_add_tour>
+      //
+      // Examples:
+      //   firstnode/oa_space/spaces
+      //   firstnode/oa_space
+      if ($path_parts[0] == 'firstnode') {
+        $node_type = $path_parts[1];
+        $node_add_tour = count($path_parts) > 2 ? $path_parts[2] : NULL;
+        $redirect_path = NULL;
+        $nid = db_select('node', 'n')
+          ->fields('n', array('nid'))
+          ->condition('type', $node_type)
+          ->orderBy('nid', 'DESC')
+          ->range(0,1)
+          ->execute()
+          ->fetchField();
+      }
+      // Special step path: mynode/<node_type>:<node_add_tour>/<path>
+      //
+      // Examples:
+      //   mynode/oa_space/group
+      //   mynode/oa_space/admin/appearance
+      //   mynode/oa_space:spaces
+      //   mynode/oa_space:spaces/group
+      elseif ($path_parts[0] == 'mynode') {
+        // Get the optional path to redirect to.
+        $redirect_path = count($path_parts) > 2 ? implode('/', array_slice($path_parts, 2)) : NULL;
+
+        // The node type can optionally list a tour (after a colon) to use when
+        // adding that node type, if none exists, for example: oa_space:spaces.
+        $node_type_parts = explode(':', $path_parts[1]);
+        $node_type = $node_type_parts[0];
+        $node_add_tour = count($node_type_parts) > 1 ? $node_type_parts[1] : NULL;
+
+        $nid = db_select('node', 'n')
+          ->fields('n', array('nid'))
+          ->condition('type', $node_type)
+          ->condition('uid', $user->uid)
+          ->orderBy('nid', 'DESC')
+          ->range(0,1)
+          ->execute()
+          ->fetchField();
+      }
+
       if (empty($nid)) {
-        // No nodes exist yet so let's send them to the node add form.
-        $tour->steps[$key]['path'] = 'node/add/' . str_replace('_', '-', $node_type) . '?nexttour=' . $tour->name;
-        if (!empty($path_parts[2])) {
-          // If the URL has a 3rd part, that's the name of the tour to run on the node add form.
-          $tour->steps[$key]['path'] .= '&tour=' . $path_parts[2];
+        $node_add_path = 'node/add/' . str_replace('_', '-', $node_type);
+        if ($node_type == 'oa_space') {
+          // TODO: We should look up the first Space type.
+          $node_add_path .= '/1';
         }
-      } else {
+        $node_add_path .= '?nexttour=' . $tour->name;
+
+        // No nodes exist yet so let's send them to the node add form.
+        $tour->steps[$key]['path'] = $node_add_path;
+        if (!empty($node_add_tour)) {
+          // If the URL has a 3rd part, that's the name of the tour to run on the node add form.
+          $tour->steps[$key]['path'] .= '&tour=' . $node_add_tour;
+        }
+      }
+      else {
         // A node does exist, so go ahead and make that the next step.
-        $tour->steps[$key]['path'] = drupal_get_path_alias('node/' . $nid);
+        if (!empty($redirect_path) && strpos($redirect_path, '%') !== FALSE) {
+          $node_path = str_replace('%', $nid, $redirect_path);
+        }
+        else {
+          $node_path = 'node/' . $nid;
+          if (!empty($redirect_path)) {
+            $node_path .= '/' . $path_parts[2];
+          }
+        }
+        $tour->steps[$key]['path'] = drupal_get_path_alias($node_path);
+
         if (!empty($_SESSION['nexttour']) && $_SESSION['nexttour'] == $tour->name) {
           for ($i = 0; $i < $key; $i++) {
             unset($tour->steps[$i]);

--- a/modules/oa_tour/oa_tour.module
+++ b/modules/oa_tour/oa_tour.module
@@ -70,9 +70,15 @@ function oa_tour_bootstrap_tour_presave_alter(&$tour, &$vals) {
  * Dig into steps with special paths and alter them so that they either point
  * to the first node of a specific type if one exists, or the node add form of
  * that type if not.
+ * 
+ * Also, modify steps that need to add an oa_space to go directly to the the
+ * first Space Blueprint, so that it doesn't break the tour.
  */
 function oa_tour_bootstrap_tour_alter(&$tour) {
   global $user;
+
+  $space_blueprints = taxonomy_get_tree(taxonomy_vocabulary_machine_name_load('space_type')->vid, 0, 1);
+  $section_types = taxonomy_get_tree(taxonomy_vocabulary_machine_name_load('section_type')->vid, 0, 1);
 
   if (empty($tour) || empty($tour->steps)) {
     return;
@@ -131,8 +137,7 @@ function oa_tour_bootstrap_tour_alter(&$tour) {
       if (empty($nid)) {
         $node_add_path = 'node/add/' . str_replace('_', '-', $node_type);
         if ($node_type == 'oa_space') {
-          // TODO: We should look up the first Space type.
-          $node_add_path .= '/1';
+          $node_add_path .= '/' . $space_blueprints[0]->tid;
         }
         $node_add_path .= '?nexttour=' . $tour->name;
 
@@ -163,6 +168,14 @@ function oa_tour_bootstrap_tour_alter(&$tour) {
           $tour->steps = array_values($tour->steps);
         }
       }
+    }
+    elseif ($step['path'] == 'node/add/oa-space') {
+      // Redirect straight to the first Space Blueprint.
+      $tour->steps[$key]['path'] .= '/' . $space_blueprints[0]->tid;
+    }
+    elseif ($step['path'] == 'node/add/oa-section') {
+      // Redirect straight to the first Section Type.
+      $tour->steps[$key]['path'] .= '/' . $section_types[0]->tid;
     }
   }
 }

--- a/modules/oa_tour_defaults/oa_tour_defaults.bootstrap_tour_tour.inc
+++ b/modules/oa_tour_defaults/oa_tour_defaults.bootstrap_tour_tour.inc
@@ -21,7 +21,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '#edit-field-oa-banner-position-und',
-      'path' => 'node/add/oa-space',
+      'path' => 'node/add/oa-space/1',
       'placement' => 'right',
       'title' => 'Space Banner',
       'content' => '<p><span>Select a banner image to be uploaded. &nbsp;</span></p><p><span>Banner images should have an aspect ratio appropriate for streching across the full width of the site.</span></p>',
@@ -105,7 +105,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     1 => array(
       'selector' => '',
-      'path' => 'node/4/group',
+      'path' => 'mynode/oa_space:spaces/group',
       'placement' => 'right',
       'title' => 'Change Appearance',
       'content' => '<p><span>Click the Appearance link to change the Colors for the Space.</span></p>',
@@ -113,7 +113,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     2 => array(
       'selector' => '#edit-scheme',
-      'path' => 'group/node/4/admin/appearance',
+      'path' => 'mynode/oa_space:spaces/group/node/%/admin/appearance',
       'placement' => 'right',
       'title' => 'Colorizer Settings',
       'content' => '<p>Select a pre-defined color scheme for your Space.</p><p>Or, click on a spacific color to change it.</p>',
@@ -121,7 +121,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     3 => array(
       'selector' => '.farbtastic',
-      'path' => 'group/node/4/admin/appearance',
+      'path' => '',
       'placement' => 'right',
       'title' => 'Changing Colors',
       'content' => '<p><span>As you change the color using the color picker, the colors on the page will change automatically.</span></p>',
@@ -129,7 +129,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     4 => array(
       'selector' => '#edit-colorizer-clearcache',
-      'path' => 'group/node/4/admin/appearance',
+      'path' => '',
       'placement' => 'right',
       'title' => 'Save your Changes',
       'content' => '<p>When you are finished customizing the colors, click Save.</p><p>The Clear Colorizer Cache is used to refresh the colors if the underlying theme files are updated.</p>',
@@ -137,7 +137,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     5 => array(
       'selector' => '.form-item-colorizer-reset label',
-      'path' => 'group/node/4/admin/appearance',
+      'path' => '',
       'placement' => 'right',
       'title' => 'Resetting Colors',
       'content' => '<p><span>To reset colors back to the default theme, click this box and then Save.</span></p><p></p>',
@@ -157,7 +157,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '#ajax-link',
-      'path' => 'firstnode/oa_space/spaces',
+      'path' => 'mynode/oa_space:spaces',
       'placement' => 'bottom',
       'title' => 'Configure Layout',
       'content' => '<p>When you create a space, you have the option of configuring the layout according to a number of built in templates.&nbsp;</p><p>Click "Change this Layout" to choose from 31 built in content layouts.</p>',
@@ -185,7 +185,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '.pane-node-group-access',
-      'path' => 'node/add/oa-space',
+      'path' => 'node/add/oa-space/1',
       'placement' => 'left',
       'title' => 'Content Visibility',
       'content' => '<p>You have the ability to determine whether or not your content is public or private.</p><p>This can be done all the way from your highest level space to your most heavily nested section.</p>',
@@ -329,7 +329,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     2 => array(
       'selector' => '.pane-node-form-menu',
-      'path' => 'node/add/oa-space',
+      'path' => 'node/add/oa-space/1',
       'placement' => 'left',
       'title' => 'Adding Items to Menu',
       'content' => '<p><span>To add something to the menu, edit the item and enable the menu link option, then select Main Menu in the Parent dropdown.</span></p><p><span>You can add items to menus at the space as well as the section level. Merely give menu link the title you\'d like and nest it appropriately.&nbsp;</span></p>',
@@ -345,7 +345,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     4 => array(
       'selector' => 'dt:nth-child(7) a',
-      'path' => 'node/4/group',
+      'path' => 'mynode/oa_space:spaces/group',
       'placement' => 'right',
       'title' => 'Space Menu',
       'content' => '<p><span>Select the Menu option.</span></p>',
@@ -353,7 +353,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     5 => array(
       'selector' => '.form-item-oa-space-menu label',
-      'path' => 'group/node/4/admin/menu',
+      'path' => 'mynode/oa_space:spaces/group/node/%/admin/menu',
       'placement' => 'right',
       'title' => 'Space Menu',
       'content' => '<p><span>Check this box and Save to display the Space-specific menu below the toolbar.</span></p>',

--- a/modules/oa_tour_defaults/oa_tour_defaults.bootstrap_tour_tour.inc
+++ b/modules/oa_tour_defaults/oa_tour_defaults.bootstrap_tour_tour.inc
@@ -21,7 +21,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '#edit-field-oa-banner-position-und',
-      'path' => 'node/add/oa-space/1',
+      'path' => 'node/add/oa-space',
       'placement' => 'right',
       'title' => 'Space Banner',
       'content' => '<p><span>Select a banner image to be uploaded. &nbsp;</span></p><p><span>Banner images should have an aspect ratio appropriate for streching across the full width of the site.</span></p>',
@@ -185,7 +185,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '.pane-node-group-access',
-      'path' => 'node/add/oa-space/1',
+      'path' => 'node/add/oa-space',
       'placement' => 'left',
       'title' => 'Content Visibility',
       'content' => '<p>You have the ability to determine whether or not your content is public or private.</p><p>This can be done all the way from your highest level space to your most heavily nested section.</p>',
@@ -329,7 +329,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     2 => array(
       'selector' => '.pane-node-form-menu',
-      'path' => 'node/add/oa-space/1',
+      'path' => 'node/add/oa-space',
       'placement' => 'left',
       'title' => 'Adding Items to Menu',
       'content' => '<p><span>To add something to the menu, edit the item and enable the menu link option, then select Main Menu in the Parent dropdown.</span></p><p><span>You can add items to menus at the space as well as the section level. Merely give menu link the title you\'d like and nest it appropriately.&nbsp;</span></p>',
@@ -857,7 +857,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '#parent-dropdown',
-      'path' => 'firstnode/oa_space/spaces',
+      'path' => 'mynode/oa_space:spaces',
       'placement' => 'bottom',
       'title' => 'Creating a Subspace',
       'content' => '<p>Welcome to your new space!&nbsp;</p><p>Some organizations will require an additional large collection of content nested within their space.&nbsp;We call these subspaces.&nbsp;</p><p>We create a subspace by going to "Create new Space."&nbsp;</p><p>For now, click "next" to get started with your first subspace.</p><p></p>',


### PR DESCRIPTION
Several of the default tours don't work. The two main reasons are:
1. Space/Section types now have their own creation pages, and the redirect from (for example) node/add/oa-space to node/add/oa-space/1 is breaking the tour! My PR works around this by rewriting both node/add/oa-space and node/add/oa-section to the first available typed path. You can reproduce this and test the fix by trying the "Banners" tour: it's first step should show a tour popup.
2. There were some NIDs hard-coded in a couple tours. For example, "Colorizing a Space" hard-coded an NID of 4 in the 2nd (and later) steps. My PR works around this by adding another special path (in addition to "firstnode") called "mynode" which returns the most recently created node of a type, which is owned by the current user, and allows you to go to a path based on the node (so, not just directly viewing the node, but redirecting to node/X/group, for example). Look at the diff for a couple examples of what this looks like.

I've been able to click "Next" all the way to the end on all the default tours using this PR! Please let me know what you think.
