### PR TITLE
Go to a Space page in order to access the 'contextual dropdown'.

### DIFF
--- a/modules/oa_tour_defaults/oa_tour_defaults.bootstrap_tour_tour.inc
+++ b/modules/oa_tour_defaults/oa_tour_defaults.bootstrap_tour_tour.inc
@@ -97,7 +97,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
   $bootstrap_tour->steps = array(
     0 => array(
       'selector' => '#contextual-dropdown',
-      'path' => '<front>',
+      'path' => 'mynode/oa_space:spaces',
       'placement' => 'left',
       'title' => 'Customizing Colors',
       'content' => '<p><span>To change the Colors of a Space, select the Config option from the contextual drop-down menu.</span></p>',
@@ -337,7 +337,7 @@ function oa_tour_defaults_default_bootstrap_tour() {
     ),
     3 => array(
       'selector' => '#contextual-dropdown',
-      'path' => '<front>',
+      'path' => 'mynode/oa_space:spaces',
       'placement' => 'left',
       'title' => 'Space Menus',
       'content' => '<p><span>To display the space-specific menu, select Config from the contextual drop-down.</span></p>',


### PR DESCRIPTION
I found another error in the tours. It's going to the front page to point at the 'contextual dropdown' for a Space, rather than going to a Space. I hadn't noticed it previously, because it'll actually just skip over the 'contextual dropdown' step entirely and go straight to the next step. Anyway, this PR will cause that step to be actually shown!
