### PR TITLE
Add 'Include archived content' exposed Views filter to core widgets.

### DIFF
--- a/modules/oa_admin/oa_admin.views_default.inc
+++ b/modules/oa_admin/oa_admin.views_default.inc
@@ -141,6 +141,14 @@ function oa_admin_views_default_views() {
     'forums' => 0,
     'tags' => 0,
   );
+  /* Relationship: Flags: trash */
+  $handler->display->display_options['relationships']['flag_content_rel']['id'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['flag_content_rel']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['label'] = 'archived';
+  $handler->display->display_options['relationships']['flag_content_rel']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel']['flag'] = 'trash';
+  $handler->display->display_options['relationships']['flag_content_rel']['user_scope'] = 'any';
   /* Field: Bulk operations: Content */
   $handler->display->display_options['fields']['views_bulk_operations']['id'] = 'views_bulk_operations';
   $handler->display->display_options['fields']['views_bulk_operations']['table'] = 'node';
@@ -426,6 +434,23 @@ function oa_admin_views_default_views() {
   $handler->display->display_options['filters']['vid']['expose']['operator'] = 'vid_op';
   $handler->display->display_options['filters']['vid']['expose']['identifier'] = 'vid';
   $handler->display->display_options['filters']['vid']['expose']['remember'] = TRUE;
+  /* Filter criterion: Flags: Flagged */
+  $handler->display->display_options['filters']['flagged']['id'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['table'] = 'flag_content';
+  $handler->display->display_options['filters']['flagged']['field'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['relationship'] = 'flag_content_rel';
+  $handler->display->display_options['filters']['flagged']['value'] = '0';
+  $handler->display->display_options['filters']['flagged']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['flagged']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['flagged']['expose']['label'] = 'Include archived content';
+  $handler->display->display_options['filters']['flagged']['expose']['operator'] = 'flagged_op';
+  $handler->display->display_options['filters']['flagged']['expose']['identifier'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
 
   /* Display: System */
   $handler = $view->new_display('system', 'System', 'oa_system');

--- a/modules/oa_archive/oa_archive.module
+++ b/modules/oa_archive/oa_archive.module
@@ -16,3 +16,43 @@ function oa_archive_node_access($node, $op, $account) {
     return NODE_ACCESS_DENY;
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function oa_archive_form_views_content_views_panes_content_type_edit_form_alter(&$form, &$form_state, $form_id) {
+  $view = $form_state['view'];
+  $conf = $form_state['conf'];
+
+  // We need to locate an exposed filter on the View which is the 'Archive'
+  // flag. This is a little harder than it could be because the filter needs a
+  // relationship to the right flag.
+  foreach($view->filter as $filter_name => $filter) {
+    if (is_a($filter, 'flag_handler_filter_flagged') && !empty($filter->options['exposed'])) {
+      if ($relationship = $view->relationship[$filter->options['relationship']]) {
+        if ($relationship->options['flag'] == 'trash') {
+          _oa_archive_alter_archive_exposed_filter($form, $filter_name, $conf);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Helper function to alter the 'Archive' exposed filter to be user friendly.
+ */
+function _oa_archive_alter_archive_exposed_filter(&$form, $name, $conf) {
+  if (isset($form['exposed']['filter-' . $name])) {
+    // Replace the options with easier to understand ones.
+    $form['exposed']['filter-' . $name]['flagged']['#options'] = array(
+      '0'   => t('No'),
+      'All' => t('Yes'),
+      '1'   => t('Only archived content'),
+    );
+
+    // Default to 'No' when there is no previous configuration.
+    if (!isset($conf['exposed']['flagged'])) {
+      $form['exposed']['filter-' . $name]['flagged']['#default_value'] = '0';
+    }
+  }
+}

--- a/modules/oa_archive/oa_archive.module
+++ b/modules/oa_archive/oa_archive.module
@@ -20,9 +20,35 @@ function oa_archive_node_access($node, $op, $account) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function oa_archive_form_views_exposed_form_alter(&$form, &$form_state) {
+  // Alter the 'Archived' exposed filter when shown normally.
+  foreach (_oa_archive_find_archived_exposed_filters($form_state['view']) as $filter_name) {
+    if (isset($form[$filter_name])) {
+      _oa_archive_alter_archived_exposed_filter($form[$filter_name]);
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function oa_archive_form_views_content_views_panes_content_type_edit_form_alter(&$form, &$form_state, $form_id) {
-  $view = $form_state['view'];
-  $conf = $form_state['conf'];
+  // Alter the 'Archived' exposed filter when shown on the pane settings.
+  foreach (_oa_archive_find_archived_exposed_filters($form_state['view']) as $filter_name) {
+    if (isset($form['exposed']['filter-' . $filter_name][$filter_name])) {
+      _oa_archive_alter_archived_exposed_filter($form['exposed']['filter-' . $filter_name][$filter_name]);
+    }
+  }
+}
+
+/**
+ * Helper function to find the 'Archived' exposed filters on a View.
+ *
+ * @return array
+ *   An array of the filter names.
+ */
+function _oa_archive_find_archived_exposed_filters($view) {
+  $result = array();
 
   // We need to locate an exposed filter on the View which is the 'Archive'
   // flag. This is a little harder than it could be because the filter needs a
@@ -31,28 +57,28 @@ function oa_archive_form_views_content_views_panes_content_type_edit_form_alter(
     if (is_a($filter, 'flag_handler_filter_flagged') && !empty($filter->options['exposed'])) {
       if ($relationship = $view->relationship[$filter->options['relationship']]) {
         if ($relationship->options['flag'] == 'trash') {
-          _oa_archive_alter_archive_exposed_filter($form, $filter_name, $conf);
+          $result[] = $filter_name;
         }
       }
     }
   }
+
+  return $result;
 }
 
 /**
  * Helper function to alter the 'Archive' exposed filter to be user friendly.
  */
-function _oa_archive_alter_archive_exposed_filter(&$form, $name, $conf) {
-  if (isset($form['exposed']['filter-' . $name])) {
-    // Replace the options with easier to understand ones.
-    $form['exposed']['filter-' . $name][$name]['#options'] = array(
-      '0'   => t('No'),
-      'All' => t('Yes'),
-      '1'   => t('Only archived content'),
-    );
+function _oa_archive_alter_archived_exposed_filter(&$element) {
+  // Replace the options with easier to understand ones.
+  $element['#options'] = array(
+    '0'   => t('No'),
+    'All' => t('Yes'),
+    '1'   => t('Only archived content'),
+  );
 
-    // Default to 'No' when there is no previous configuration.
-    if (!isset($conf['exposed'][$name])) {
-      $form['exposed']['filter-' . $name][$name]['#default_value'] = '0';
-    }
+  // Default to 'No' when there is no previous configuration.
+  if (empty($element['#default_value'])) {
+    $element['#default_value'] = 0;
   }
 }

--- a/modules/oa_archive/oa_archive.module
+++ b/modules/oa_archive/oa_archive.module
@@ -44,15 +44,15 @@ function oa_archive_form_views_content_views_panes_content_type_edit_form_alter(
 function _oa_archive_alter_archive_exposed_filter(&$form, $name, $conf) {
   if (isset($form['exposed']['filter-' . $name])) {
     // Replace the options with easier to understand ones.
-    $form['exposed']['filter-' . $name]['flagged']['#options'] = array(
+    $form['exposed']['filter-' . $name][$name]['#options'] = array(
       '0'   => t('No'),
       'All' => t('Yes'),
       '1'   => t('Only archived content'),
     );
 
     // Default to 'No' when there is no previous configuration.
-    if (!isset($conf['exposed']['flagged'])) {
-      $form['exposed']['filter-' . $name]['flagged']['#default_value'] = '0';
+    if (!isset($conf['exposed'][$name])) {
+      $form['exposed']['filter-' . $name][$name]['#default_value'] = '0';
     }
   }
 }

--- a/modules/oa_layouts/oa_layouts.panelizer.inc
+++ b/modules/oa_layouts/oa_layouts.panelizer.inc
@@ -653,8 +653,7 @@ function oa_layouts_panelizer_defaults() {
       'view_mode' => 'teaser',
       'widget_title' => '',
       'exposed' => array(
-        'sort_by' => NULL,
-        'sort_order' => NULL,
+        'flagged' => '0',
       ),
       'offset' => NULL,
       'link_to_view' => NULL,

--- a/modules/oa_news/oa_news.panelizer.inc
+++ b/modules/oa_news/oa_news.panelizer.inc
@@ -122,6 +122,7 @@ function oa_news_panelizer_defaults() {
       'items_per_page' => '10',
       'fields_override' => array(
         'title' => 1,
+        'timestamp' => 1,
         'created' => 1,
         'body' => 1,
         'name' => 1,
@@ -137,7 +138,9 @@ function oa_news_panelizer_defaults() {
         'og_group_ref_target_id' => '',
         'og_group_ref_target_id_mine' => 0,
         'og_subspaces_view_all' => 0,
+        'og_subspaces_view_parent' => 0,
         'oa_section_ref_target_id' => '',
+        'flagged' => '0',
       ),
       'context' => array(
         0 => 'relationship_entity_from_field:og_group_ref-node-node_1',

--- a/modules/oa_news/oa_news.views_default.inc
+++ b/modules/oa_news/oa_news.views_default.inc
@@ -40,6 +40,14 @@ function oa_news_views_default_views() {
   $handler->display->display_options['relationships']['uid']['id'] = 'uid';
   $handler->display->display_options['relationships']['uid']['table'] = 'node';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  /* Relationship: Flags: trash */
+  $handler->display->display_options['relationships']['flag_content_rel']['id'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['flag_content_rel']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['label'] = 'archived';
+  $handler->display->display_options['relationships']['flag_content_rel']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel']['flag'] = 'trash';
+  $handler->display->display_options['relationships']['flag_content_rel']['user_scope'] = 'any';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
@@ -222,6 +230,23 @@ function oa_news_views_default_views() {
     3 => 0,
     4 => 0,
   );
+  /* Filter criterion: Flags: Flagged */
+  $handler->display->display_options['filters']['flagged']['id'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['table'] = 'flag_content';
+  $handler->display->display_options['filters']['flagged']['field'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['relationship'] = 'flag_content_rel';
+  $handler->display->display_options['filters']['flagged']['value'] = '0';
+  $handler->display->display_options['filters']['flagged']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['flagged']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['flagged']['expose']['label'] = 'Include archived content';
+  $handler->display->display_options['filters']['flagged']['expose']['operator'] = 'flagged_op';
+  $handler->display->display_options['filters']['flagged']['expose']['identifier'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
 
   /* Display: Recent News */
   $handler = $view->new_display('panel_pane', 'Recent News', 'oa_recent_news');
@@ -244,6 +269,7 @@ function oa_news_views_default_views() {
       'type' => '',
       'og_group_ref_target_id' => '',
       'oa_section_ref_target_id' => '',
+      'flagged' => '',
     ),
   );
   $export['open_atrium_news'] = $view;

--- a/modules/oa_panopoly_users/oa_panopoly_users.features.features_overrides.inc
+++ b/modules/oa_panopoly_users/oa_panopoly_users.features.features_overrides.inc
@@ -102,7 +102,18 @@ function oa_panopoly_users_features_override_default_overrides() {
       'subtype' => 'open_atrium_discussions-discussion_user_reply',
       'shown' => TRUE,
       'access' => array(),
-      'configuration' => array(),
+      'configuration' => array(
+        'use_pager' => 1,
+        'pager_id' => 0,
+        'items_per_page' => 20,
+        'exposed' => array(
+          'type' => 'All',
+          'flagged' => 0,
+        ),
+        'view_settings' => 'fields',
+        'header_type' => 'none',
+        'view_mode' => 'teaser',
+      ),
       'cache' => array(),
       'css' => array(),
       'extras' => array(),
@@ -152,6 +163,7 @@ function oa_panopoly_users_features_override_default_overrides() {
         'items_per_page' => 20,
         'exposed' => array(
           'type' => 'oa_discussion_post',
+          'flagged' => 0,
         ),
         'context' => array(
           0 => 'empty',

--- a/modules/oa_panopoly_users/oa_panopoly_users.features.inc
+++ b/modules/oa_panopoly_users/oa_panopoly_users.features.inc
@@ -104,7 +104,18 @@ function oa_panopoly_users_panelizer_defaults_override_alter(&$data) {
           'subtype' => 'open_atrium_discussions-discussion_user_reply',
           'shown' => TRUE,
           'access' => array(),
-          'configuration' => array(),
+          'configuration' => array(
+            'use_pager' => 1,
+            'pager_id' => 0,
+            'items_per_page' => 20,
+            'exposed' => array(
+              'type' => 'All',
+              'flagged' => 0,
+            ),
+            'view_settings' => 'fields',
+            'header_type' => 'none',
+            'view_mode' => 'teaser',
+          ),
           'cache' => array(),
           'css' => array(),
           'extras' => array(),
@@ -153,6 +164,7 @@ function oa_panopoly_users_panelizer_defaults_override_alter(&$data) {
             'items_per_page' => 20,
             'exposed' => array(
               'type' => 'oa_discussion_post',
+              'flagged' => 0,
             ),
             'context' => array(
               0 => 'empty',

--- a/modules/oa_sections/oa_sections.views_default.inc
+++ b/modules/oa_sections/oa_sections.views_default.inc
@@ -122,6 +122,14 @@ function oa_sections_views_default_views() {
   $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';
   $handler->display->display_options['relationships']['og_membership_rel']['table'] = 'node';
   $handler->display->display_options['relationships']['og_membership_rel']['field'] = 'og_membership_rel';
+  /* Relationship: Flags: trash */
+  $handler->display->display_options['relationships']['flag_content_rel']['id'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['flag_content_rel']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['label'] = 'archived';
+  $handler->display->display_options['relationships']['flag_content_rel']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel']['flag'] = 'trash';
+  $handler->display->display_options['relationships']['flag_content_rel']['user_scope'] = 'any';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
@@ -161,6 +169,23 @@ function oa_sections_views_default_views() {
   $handler->display->display_options['filters']['type']['value'] = array(
     'oa_section' => 'oa_section',
   );
+  /* Filter criterion: Flags: Flagged */
+  $handler->display->display_options['filters']['flagged']['id'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['table'] = 'flag_content';
+  $handler->display->display_options['filters']['flagged']['field'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['relationship'] = 'flag_content_rel';
+  $handler->display->display_options['filters']['flagged']['value'] = '0';
+  $handler->display->display_options['filters']['flagged']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['flagged']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['flagged']['expose']['label'] = 'Include archived content';
+  $handler->display->display_options['filters']['flagged']['expose']['operator'] = 'flagged_op';
+  $handler->display->display_options['filters']['flagged']['expose']['identifier'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
 
   /* Display: Section Pages within Spaces */
   $handler = $view->new_display('panel_pane', 'Section Pages within Spaces', 'section_pages_within_spaces');
@@ -175,8 +200,14 @@ function oa_sections_views_default_views() {
   $handler->display->display_options['allow']['more_link'] = 'more_link';
   $handler->display->display_options['allow']['path_override'] = 0;
   $handler->display->display_options['allow']['title_override'] = 'title_override';
-  $handler->display->display_options['allow']['exposed_form'] = 0;
+  $handler->display->display_options['allow']['exposed_form'] = 'exposed_form';
+  $handler->display->display_options['allow']['exposed_form_configure'] = 0;
   $handler->display->display_options['allow']['fields_override'] = 'fields_override';
+  $handler->display->display_options['exposed_form_overrides'] = array(
+    'filters' => array(
+      'flagged' => '',
+    ),
+  );
   $handler->display->display_options['argument_input'] = array(
     'gid' => array(
       'type' => 'context',

--- a/oa_core.views_default.inc
+++ b/oa_core.views_default.inc
@@ -119,6 +119,14 @@ function oa_core_views_default_views() {
   $handler->display->display_options['relationships']['uid']['id'] = 'uid';
   $handler->display->display_options['relationships']['uid']['table'] = 'node';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  /* Relationship: Flags: trash */
+  $handler->display->display_options['relationships']['flag_content_rel']['id'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['flag_content_rel']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel']['label'] = 'archived';
+  $handler->display->display_options['relationships']['flag_content_rel']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel']['flag'] = 'trash';
+  $handler->display->display_options['relationships']['flag_content_rel']['user_scope'] = 'any';
   /* Field: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
@@ -246,6 +254,23 @@ function oa_core_views_default_views() {
     3 => 0,
     4 => 0,
   );
+  /* Filter criterion: Flags: Flagged */
+  $handler->display->display_options['filters']['flagged']['id'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['table'] = 'flag_content';
+  $handler->display->display_options['filters']['flagged']['field'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['relationship'] = 'flag_content_rel';
+  $handler->display->display_options['filters']['flagged']['value'] = '0';
+  $handler->display->display_options['filters']['flagged']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['flagged']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['flagged']['expose']['label'] = 'Include archived content';
+  $handler->display->display_options['filters']['flagged']['expose']['operator'] = 'flagged_op';
+  $handler->display->display_options['filters']['flagged']['expose']['identifier'] = 'flagged';
+  $handler->display->display_options['filters']['flagged']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
 
   /* Display: Recent Content */
   $handler = $view->new_display('panel_pane', 'Recent Content', 'panel_pane_2');
@@ -274,6 +299,7 @@ function oa_core_views_default_views() {
       'og_group_ref_target_id' => 'pane_and_exposed',
       'oa_section_ref_target_id' => 'pane_and_exposed',
       'uid' => 'pane_and_exposed',
+      'flagged' => '',
     ),
   );
 
@@ -336,6 +362,14 @@ function oa_core_views_default_views() {
   $handler->display->display_options['relationships']['uid']['id'] = 'uid';
   $handler->display->display_options['relationships']['uid']['table'] = 'node';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  /* Relationship: Flags: trash */
+  $handler->display->display_options['relationships']['flag_content_rel_1']['id'] = 'flag_content_rel_1';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['table'] = 'node';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['label'] = 'archived';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel_1']['flag'] = 'trash';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['user_scope'] = 'any';
   /* Relationship: Flags: subscribe_section_content */
   $handler->display->display_options['relationships']['flag_content_rel']['id'] = 'flag_content_rel';
   $handler->display->display_options['relationships']['flag_content_rel']['table'] = 'node';
@@ -423,6 +457,7 @@ function oa_core_views_default_views() {
       'og_group_ref_target_id' => 'pane_and_exposed',
       'oa_section_ref_target_id' => 'pane_and_exposed',
       'uid' => 'pane_and_exposed',
+      'flagged' => '',
     ),
     'sorts' => array(
       'changed' => 'pane_and_exposed',
@@ -467,6 +502,14 @@ function oa_core_views_default_views() {
   $handler->display->display_options['relationships']['flag_content_rel']['field'] = 'flag_content_rel';
   $handler->display->display_options['relationships']['flag_content_rel']['required'] = 0;
   $handler->display->display_options['relationships']['flag_content_rel']['flag'] = 'favorite_space';
+  /* Relationship: Flags: trash */
+  $handler->display->display_options['relationships']['flag_content_rel_1']['id'] = 'flag_content_rel_1';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['table'] = 'node';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['field'] = 'flag_content_rel';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['label'] = 'archived';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['required'] = 0;
+  $handler->display->display_options['relationships']['flag_content_rel_1']['flag'] = 'trash';
+  $handler->display->display_options['relationships']['flag_content_rel_1']['user_scope'] = 'any';
   /* Field: Content: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
   $handler->display->display_options['fields']['title']['table'] = 'node';
@@ -562,6 +605,23 @@ function oa_core_views_default_views() {
     3 => 0,
     4 => 0,
   );
+  /* Filter criterion: Flags: Flagged */
+  $handler->display->display_options['filters']['flagged_1']['id'] = 'flagged_1';
+  $handler->display->display_options['filters']['flagged_1']['table'] = 'flag_content';
+  $handler->display->display_options['filters']['flagged_1']['field'] = 'flagged';
+  $handler->display->display_options['filters']['flagged_1']['relationship'] = 'flag_content_rel_1';
+  $handler->display->display_options['filters']['flagged_1']['value'] = '0';
+  $handler->display->display_options['filters']['flagged_1']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['flagged_1']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['flagged_1']['expose']['label'] = 'Include archived content';
+  $handler->display->display_options['filters']['flagged_1']['expose']['operator'] = 'flagged_1_op';
+  $handler->display->display_options['filters']['flagged_1']['expose']['identifier'] = 'flagged_1';
+  $handler->display->display_options['filters']['flagged_1']['expose']['remember_roles'] = array(
+    2 => '2',
+    1 => 0,
+    3 => 0,
+    4 => 0,
+  );
 
   /* Display: All spaces and groups */
   $handler = $view->new_display('panel_pane', 'All spaces and groups', 'panel_pane_all');
@@ -583,6 +643,7 @@ function oa_core_views_default_views() {
       'type' => '',
       'oa_parent_space_target_id' => '',
       'flagged' => '',
+      'flagged_1' => '',
     ),
     'sorts' => array(
       'created' => '',


### PR DESCRIPTION
I'm currently in the process of adding an "Include archived content" exposed Views filter on several of the Open Atrium widgets. I've already done the "Task list" and "User tasks" from Work Tracker.

Out of the box, if you put a "Flagged" exposed filter (like "Include archived content") on a View, it is a select box with options: "True", "False" and "-All-". This isn't very user friendly - I even have to think about it for a moment to know which option I want!

This PR will change those options to be "Yes", "No" and "Only archived content" which is much easier to understand.

Soon, I'll be submitting some other PRs to add a "Include archived content" exposed Views filter to other widgets in Open Atrium.
