### PR TITLE
Exclude archived Spaces from Breadcrumbs and add an 'Archived' tab to /spaces

### DIFF
--- a/includes/oa_core.util.inc
+++ b/includes/oa_core.util.inc
@@ -6,6 +6,7 @@
 
 /**
  * Get the group IDs of all the groups a user is an approved member of.
+ *
  * REPLACES og_get_groups_by_user() in OG and returns a list of groups
  * including subspaces
  *
@@ -15,11 +16,14 @@
  * @param $group_type
  *   (optional) The entity type of the groups to fetch. By default all group
  *   types will be fetched.
+ * @param bool $include_archived
+ *   (optional) Whether to include archived nodes or not. By default, archived
+ *   items aren't included.
  *
- * @return
+ * @return array
  *   An array with the group IDs or an empty array, or returns NULL if there was an error
  */
-function oa_core_get_groups_by_user($account = NULL, $group_type = NULL) {
+function oa_core_get_groups_by_user($account = NULL, $group_type = NULL, $include_archived = FALSE) {
   $user_groups = og_get_groups_by_user($account, $group_type);
   if (!empty($group_type) && !empty($user_groups)) {
     $user_groups = array($group_type => $user_groups);
@@ -31,6 +35,18 @@ function oa_core_get_groups_by_user($account = NULL, $group_type = NULL) {
   if (!empty($group_type)) {
     $user_groups = (!empty($user_groups[$group_type])) ? $user_groups[$group_type] : array();
   }
+
+  if (!empty($user_groups) && !$include_archived) {
+    if ($flag = flag_get_flag('trash')) {
+      // Filter out groups that are archived.
+      foreach ($user_groups as $nid) {
+        if ($flag->is_flagged($nid)) {
+          unset($user_groups[$nid]);
+        }
+      }
+    }
+  }
+
   return $user_groups;
 }
 
@@ -89,83 +105,112 @@ function oa_core_get_section_context() {
 }
 
 /**
- * Return an array of parent nids
- * @param  int $nid    nid of space/group to check
- * @param  string $bundle node type
- * @return array of parent nids
+ * Get parent Spaces and Groups.
+ *
+ * @param int $nid
+ *   The NID of the Space or Group to check.
+ * @param string $bundle
+ *   (optional) The node type. (default: OA_SPACE_TYPE)
+ * @param int $status 
+ *   (optional) If specified, the node status (ex. NODE_PUBLISHED or
+ *   NODE_NOT_PUBLISHED) to look for. If not specified, it return 
+ *   nodes of either status.
+ * @param bool $include_archived
+ *   (optional) Whether to include archived nodes or not. By default, archived
+ *   items aren't included.
+ *
+ * @return array
+ *   Array of parent NIDs.
  */
-function oa_core_get_parents($nid, $bundle = OA_SPACE_TYPE, $status = NULL) {
+function oa_core_get_parents($nid, $bundle = OA_SPACE_TYPE, $status = NULL, $include_archived = FALSE) {
   $cache = &drupal_static(__FUNCTION__);
 
-  if (!isset($cache[$nid][$bundle])) {
+  if (!isset($cache[$nid][$bundle][$status][$include_archived])) {
     $query = db_select('node', 'n');
     $query->leftJoin('og_membership', 'f', "n.nid = f.gid");
     if (isset($status)) {
       $query->condition('n.status', $status);
     }
-    $result = $query
+    $query
       ->fields('n', array('nid'))
       ->condition('f.etid', $nid)
       ->condition('f.entity_type', 'node')
       ->condition('n.type', $bundle)
       ->orderBy('n.title')
-      ->addTag('node_access')
-      ->execute()
-      ->fetchCol(0);
-    $cache[$nid][$bundle] = $result;
+      ->addTag('node_access');
+
+    if (!$include_archived) {
+      if ($flag = flag_get_flag('trash')) {
+        $query->leftJoin('flag_content', 'a', "a.fid = :fid AND a.content_id = n.nid", array(':fid' => $flag->fid));
+        // This makes sure that archived content isn't included, because 'uid'
+        // will be NULL if the join didn't connect anything.
+        $query->isNull('a.uid');
+      }
+    }
+
+    $result = $query->execute()->fetchCol(0);
+    $cache[$nid][$bundle][$status][$include_archived] = $result;
   }
-  return $cache[$nid][$bundle];
+  return $cache[$nid][$bundle][$status][$include_archived];
 }
 
 /**
- * Return an array of children groups
- * @param  int $nid    nid of space/group to check
- * @param  string $bundle node type
- * @return array of children nids
+ * Get child Spaces or Groups.
+ *
+ * @param int $nid
+ *   The NID of the Space or Group to check.
+ * @param string $bundle
+ *   (optional) The node type. (default: OA_SPACE_TYPE)
+ * @param int $status 
+ *   (optional) If specified, the node status (ex. NODE_PUBLISHED or
+ *   NODE_NOT_PUBLISHED) to look for. If not specified, it return 
+ *   nodes of either status.
+ * @param bool $include_archived
+ *   (optional) Whether to include archived nodes or not. By default, archived
+ *   items aren't included.
+ *
+ * @return array
+ *   Array of children NIDs.
  */
-function oa_core_get_groups_by_parent($nid, $bundle = OA_SPACE_TYPE, $status = NULL) {
+function oa_core_get_groups_by_parent($nid, $bundle = OA_SPACE_TYPE, $status = NULL, $include_archived = FALSE) {
   $cache = &drupal_static(__FUNCTION__);
 
-  if (!isset($cache[$nid][$bundle])) {
+  if (!isset($cache[$nid][$bundle][$status][$include_archived])) {
+    $query = db_select('node', 'n');
+    $query->leftJoin('og_membership', 'f', "n.nid = f.etid");
+    $query
+      ->fields('n', array('nid'))
+      ->condition('n.type', $bundle)
+      ->orderBy('n.title')
+      ->addTag('node_access');
 
     if ($nid == 0) {
-      $query = db_select('node', 'n');
-      $query->leftJoin('og_membership', 'f', "n.nid = f.etid");
-      if (isset($bundle)) {
-        $query->condition('n.type', $bundle);
-      }
-      if (isset($status)) {
-        $query->condition('n.status', $status);
-      }
-      $result = $query
-        ->fields('n', array('nid'))
-        ->isNull('f.gid')
-        ->orderBy('n.title')
-        ->addTag('node_access')
-        ->execute()
-        ->fetchCol(0);
+      $query->isNull('f.gid');
     }
     else {
-      $query = db_select('node', 'n');
-      $query->leftJoin('og_membership', 'f', "n.nid = f.etid");
-      if (isset($bundle)) {
-        $query->condition('n.type', $bundle);
-      }
-      if (isset($status)) {
-        $query->condition('n.status', $status);
-      }
-      $result = $query
-        ->fields('n', array('nid'))
+      $query
         ->condition('f.gid', $nid)
-        ->condition('f.entity_type', 'node')
-        ->orderBy('n.title')
-        ->addTag('node_access')
-        ->execute()
-        ->fetchCol(0);
+        ->condition('f.entity_type', 'node');
+    }
+
+    if (isset($status)) {
+      $query->condition('n.status', $status);
+    }
+
+    if (!$include_archived) {
+      if ($flag = flag_get_flag('trash')) {
+        $query->leftJoin('flag_content', 'a', "a.fid = :fid AND a.content_id = n.nid", array(':fid' => $flag->fid));
+        // This makes sure that archived content isn't included, because 'uid'
+        // will be NULL if the join didn't connect anything.
+        $query->isNull('a.uid');
       }
-    $cache[$nid][$bundle] = $result;
+    }
+
+    $result = $query->execute()->fetchCol(0);
+    $cache[$nid][$bundle][$status][$include_archived] = $result;
   }
-  return $cache[$nid][$bundle];
+
+  return $cache[$nid][$bundle][$status][$include_archived];
 }
 
 /**
@@ -355,15 +400,29 @@ function oa_core_truncate_list($list, $count, $more_link = '', $always_link = FA
 }
 
 /**
- * Return a list of public spaces
- * since og_get_entity_groups doesn't return anything for anonymous users
+ * Get a list of public spaces.
+ *
+ * Necessary since og_get_entity_groups() doesn't return anything for anonymous users
+ *
+ * @param array $group_types
+ *   (optional) An associative array of node types.
+ *   (default: array(OA_SPACE_TYPE => OA_SPACE_TYPE)
+ * @param int $status 
+ *   (optional) If specified, the node status (ex. NODE_PUBLISHED or
+ *   NODE_NOT_PUBLISHED) to look for. If not specified, it return 
+ *   nodes of either status.
+ * @param bool $include_archived
+ *   (optional) Whether to include archived nodes or not. By default, archived
+ *   items aren't included.
  *
  * @return array
- * An array of public gids
+ *   An array of Space NIDs.
  */
-function oa_core_get_public_spaces($group_types = array(OA_SPACE_TYPE => OA_SPACE_TYPE), $status = NULL) {
-  $public_spaces = &drupal_static(__FUNCTION__);
-  if (!isset($public_spaces)) {
+function oa_core_get_public_spaces($group_types = array(OA_SPACE_TYPE => OA_SPACE_TYPE), $status = NULL, $include_archived = FALSE) {
+  $cache = &drupal_static(__FUNCTION__);
+
+  $group_types_cid = implode(',', $group_types);
+  if (!isset($cache[$group_types_cid][$status][$include_archived])) {
     $query = db_select('node', 'n');
     $query->rightJoin('field_data_group_access', 'g', "n.nid = g.entity_id AND g.entity_type = 'node'");
     $query
@@ -373,9 +432,19 @@ function oa_core_get_public_spaces($group_types = array(OA_SPACE_TYPE => OA_SPAC
     if (isset($status)) {
       $query->condition('n.status', $status);
     }
-    $public_spaces = $query->execute()->fetchCol(0);
+    if (!$include_archived) {
+      if ($flag = flag_get_flag('trash')) {
+        $query->leftJoin('flag_content', 'a', "a.fid = :fid AND a.content_id = n.nid", array(':fid' => $flag->fid));
+        // This makes sure that archived content isn't included, because 'uid'
+        // will be NULL if the join didn't connect anything.
+        $query->isNull('a.uid');
+      }
+    }
+
+    $cache[$group_types_cid][$status][$include_archived] = $query->execute()->fetchCol(0);
   }
-  return $public_spaces;
+
+  return $cache[$group_types_cid][$status][$include_archived];
 }
 
 /**

--- a/includes/oa_core.util.inc
+++ b/includes/oa_core.util.inc
@@ -109,9 +109,10 @@ function oa_core_get_section_context() {
  *
  * @param int $nid
  *   The NID of the Space or Group to check.
- * @param string $bundle
- *   (optional) The node type. (default: OA_SPACE_TYPE)
- * @param int $status 
+ * @param string|NULL $bundle
+ *   (optional) The node type (default: OA_SPACE_TYPE). If NULL is passed, it
+ *   will include all node types.
+ * @param int|NULL $status 
  *   (optional) If specified, the node status (ex. NODE_PUBLISHED or
  *   NODE_NOT_PUBLISHED) to look for. If not specified, it return 
  *   nodes of either status.
@@ -128,6 +129,9 @@ function oa_core_get_parents($nid, $bundle = OA_SPACE_TYPE, $status = NULL, $inc
   if (!isset($cache[$nid][$bundle][$status][$include_archived])) {
     $query = db_select('node', 'n');
     $query->leftJoin('og_membership', 'f', "n.nid = f.gid");
+    if (isset($bundle)) {
+      $query->condition('n.type', $bundle);
+    }
     if (isset($status)) {
       $query->condition('n.status', $status);
     }
@@ -135,7 +139,6 @@ function oa_core_get_parents($nid, $bundle = OA_SPACE_TYPE, $status = NULL, $inc
       ->fields('n', array('nid'))
       ->condition('f.etid', $nid)
       ->condition('f.entity_type', 'node')
-      ->condition('n.type', $bundle)
       ->orderBy('n.title')
       ->addTag('node_access');
 

--- a/includes/oa_core.util.inc
+++ b/includes/oa_core.util.inc
@@ -162,9 +162,10 @@ function oa_core_get_parents($nid, $bundle = OA_SPACE_TYPE, $status = NULL, $inc
  *
  * @param int $nid
  *   The NID of the Space or Group to check.
- * @param string $bundle
- *   (optional) The node type. (default: OA_SPACE_TYPE)
- * @param int $status 
+ * @param string|NULL $bundle
+ *   (optional) The node type (default: OA_SPACE_TYPE). If NULL is passed, it
+ *   will include all node types.
+ * @param int|NULL $status 
  *   (optional) If specified, the node status (ex. NODE_PUBLISHED or
  *   NODE_NOT_PUBLISHED) to look for. If not specified, it return 
  *   nodes of either status.
@@ -196,6 +197,9 @@ function oa_core_get_groups_by_parent($nid, $bundle = OA_SPACE_TYPE, $status = N
         ->condition('f.entity_type', 'node');
     }
 
+    if (isset($bundle)) {
+      $query->condition('n.type', $bundle);
+    }
     if (isset($status)) {
       $query->condition('n.status', $status);
     }

--- a/includes/oa_core.util.inc
+++ b/includes/oa_core.util.inc
@@ -32,19 +32,19 @@ function oa_core_get_groups_by_user($account = NULL, $group_type = NULL, $includ
     $user_groups = og_subgroups_children_load_multiple($user_groups);
   }
 
-  if (!empty($group_type)) {
-    $user_groups = (!empty($user_groups[$group_type])) ? $user_groups[$group_type] : array();
-  }
-
   if (!empty($user_groups) && !$include_archived) {
     if ($flag = flag_get_flag('trash')) {
       // Filter out groups that are archived.
-      foreach ($user_groups as $nid) {
+      foreach ($user_groups['node'] as $nid) {
         if ($flag->is_flagged($nid)) {
-          unset($user_groups[$nid]);
+          unset($user_groups['node'][$nid]);
         }
       }
     }
+  }
+
+  if (!empty($group_type)) {
+    $user_groups = (!empty($user_groups[$group_type])) ? $user_groups[$group_type] : array();
   }
 
   return $user_groups;
@@ -527,12 +527,14 @@ function oa_core_get_group_users_for_space($space_id, $group_id) {
 
 /**
  * Return a list of space ids that a user belongs to.
+ *
+ * @deprecated This function is redundant - use oa_core_get_groups_by_user().
+ *
+ * @see oa_core_get_groups_by_user()
  */
 function oa_core_get_user_spaces($uid) {
-  if ($groups = og_get_entity_groups('user', $uid)) {
-    return !empty($groups['node']) ? $groups['node'] : array();
-  }
-  return array();
+  $groups = oa_core_get_groups_by_user(user_load($uid), 'node');
+  return !empty($groups) ? $groups : array();
 }
 
 /**

--- a/modules/oa_dashboard/oa_dashboard.module
+++ b/modules/oa_dashboard/oa_dashboard.module
@@ -253,7 +253,7 @@ function template_preprocess_oa_toolbar(&$vars) {
     $vars['space_label'] = $title;
     $vars['space_url'] = url('node/' . $space_id);
     if (isset($vars['show_parents'])) {
-      $parents = oa_core_get_parents($space_id, $space_type, NODE_PUBLISHED);
+      $parents = oa_core_get_parents($space_id, $space_type, NODE_PUBLISHED, TRUE);
       if (count($parents)) {
         $items = oa_core_get_titles($parents);
         if (!empty($items['titles'][0])) {
@@ -307,7 +307,7 @@ function template_preprocess_oa_toolbar(&$vars) {
       $remove = array();
       foreach ($spaces as $key => $value) {
         // parents are cached, so this should be fast
-        $parents = oa_core_get_parents($value, $space_type);
+        $parents = oa_core_get_parents($value, $space_type, NODE_PUBLISHED, TRUE);
         foreach ($parents as $parent_id) {
           if (isset($spaces[$parent_id])) {
             // parent is also in spaces list, so remove child from list

--- a/oa_core.pages_default.inc
+++ b/oa_core.pages_default.inc
@@ -100,12 +100,17 @@ function oa_core_default_page_manager_pages() {
       'show_description' => 1,
       'tabs' => array(
         'Favorite' => 'Favorite',
+        'Archived' => 'Archived',
         'Subscribed' => 'Subscribed',
         'All' => 'All',
       ),
       'link_class' => 'btn',
       'show_links' => 1,
       'num_per_page' => '15',
+      'types' => array(
+        'oa_space' => 'oa_space',
+        'oa_group' => 0,
+      ),
     );
     $pane->cache = array();
     $pane->style = array(

--- a/plugins/content_types/oa_core_user_spaces.inc
+++ b/plugins/content_types/oa_core_user_spaces.inc
@@ -6,6 +6,7 @@
  */
 
 define('SPACE_TAB_FAVORITE', 'Favorite');
+define('SPACE_TAB_ARCHIVED', 'Archived');
 define('SPACE_TAB_ACTIVE', 'Subscribed');
 define('SPACE_TAB_ALL', 'All');
 
@@ -63,6 +64,19 @@ function oa_core_user_spaces_render($subtype, $conf, $args, $context = NULL) {
     $featured_spaces = oa_core_build_space_display($featured_spaces_nodes, $conf, $account, $group_types);
   }
 
+  $archived_spaces = array();
+  if (module_exists('oa_archive') && ($flag = flag_get_flag('trash'))) {
+    $query = db_select('node', 'n');
+    $query->join('flag_content', 'a', 'a.fid = :fid AND n.nid = a.content_id', array(':fid' => $flag->fid));
+    $query
+      ->fields('n', array('nid'))
+      ->condition('n.type', $group_types, 'IN')
+      ->addTag('node_access');
+    $archived_spaces_ids = $query->execute()->fetchCol();
+    $archived_spaces_nodes = node_load_multiple($archived_spaces_ids);
+    $archived_spaces = oa_core_build_space_display($archived_spaces_nodes, $conf, $account, $group_types);
+  }
+
   $page = 0;
   // set our maximum item per page
   $num_per_page = $conf['num_per_page'];
@@ -80,6 +94,9 @@ function oa_core_user_spaces_render($subtype, $conf, $args, $context = NULL) {
             'class' => $conf['link_class'],
         )));
     }
+  }
+  if ($conf['tabs'][SPACE_TAB_ARCHIVED] && !empty($archived_spaces)) {
+    $vars['space_groups'][t(SPACE_TAB_ARCHIVED)]['spaces'] = $archived_spaces;
   }
   if ($conf['tabs'][SPACE_TAB_ALL]) {
     // pager_find_page() will return the current page number
@@ -343,6 +360,7 @@ function oa_core_user_spaces_edit_form($form, &$form_state) {
     '#title' => t('Tabs'),
     '#options' => array(
       SPACE_TAB_FAVORITE => t(SPACE_TAB_FAVORITE),
+      SPACE_TAB_ARCHIVED => t(SPACE_TAB_ARCHIVED),
       SPACE_TAB_ACTIVE => t(SPACE_TAB_ACTIVE),
       SPACE_TAB_ALL => t(SPACE_TAB_ALL),
     ),

--- a/plugins/content_types/oa_core_user_spaces.inc
+++ b/plugins/content_types/oa_core_user_spaces.inc
@@ -48,7 +48,7 @@ function oa_core_user_spaces_render($subtype, $conf, $args, $context = NULL) {
     $group_types = array(OA_SPACE_TYPE => OA_SPACE_TYPE);
   }
   $all_spaces_ids = oa_core_get_public_spaces($group_types);
-  $active_spaces_ids = oa_core_get_user_spaces($account->uid);
+  $active_spaces_ids = oa_core_get_groups_by_user($account, 'node');
   $all_spaces_ids = array_merge($all_spaces_ids, $active_spaces_ids);
 
   $all_spaces_nodes = node_load_multiple($all_spaces_ids);


### PR DESCRIPTION
Mostly does what the title says!

Also, made a couple of other changes to the functions in oa_core.util.inc that this PR was changing anyway:
1. Rewrote the Doxygen comments to Drupal coding standards
2. Made the static caching specific to _every_ argument to the function (some weren't be included which means the functions could have returned an invalid cached version on subsequent calls with different arguments)

Please let me know what you think!
