### PR TITLE
Use real user's name in content visibility widget

### DIFF
--- a/includes/oa_core.access.inc
+++ b/includes/oa_core.access.inc
@@ -470,7 +470,8 @@ function _oa_core_build_visibility_links($type, $node, $field, $bundle = '') {
       }
       elseif ($type == 'user') {
         $user = user_load($value['target_id']);
-        $links[] = l($user->name, "user/" . $user->uid);
+        $user_name = format_username($user);
+        $links[] = l($user_name, "user/" . $user->uid);
       }
     }
   }


### PR DESCRIPTION
Pass the user object through format_username() for display in the content visibility widget, rather than displaying the raw username.
