### PR TITLE
Issue #2315485: Add the is_string($condition['field']) back to prevent ...

### DIFF
--- a/oa_core.module
+++ b/oa_core.module
@@ -1274,7 +1274,7 @@ function oa_core_views_query_alter(&$view, &$query) {
       foreach ($query->where[1]['conditions'] as $key => $condition) {
         // If the field is 'og_membership.gid' or an alias for the same column.
         $column = 'og_membership';
-        if (!empty($condition['field']) && ($condition['field'] === $column ||
+        if (!empty($condition['field']) && is_string($condition['field']) && ($condition['field'] === $column ||
             substr($condition['field'], -strlen($column)-2) === "__{$column}")) {
           // Move the condition to our new where group.
           $query->add_where($group, $condition['field'], $condition['value'], $condition['operator']);


### PR DESCRIPTION
... fatal when view includes query object.

Explanation for this PR is on this comment in the Drupal.org issue queue:

https://www.drupal.org/node/2315485#comment-9059991

Please let me know what you think!
