### PR TITLE
Make digest view mode alter actually work

### DIFF
--- a/modules/oa_messages_digest/oa_messages_digest.module
+++ b/modules/oa_messages_digest/oa_messages_digest.module
@@ -28,7 +28,7 @@ function oa_messages_digest_oa_message_notifiers_alter(&$notifiers) {
  */
 function oa_messages_digest_message_digest_view_mode_alter(&$context) {
 
-  $context['view_modes'] = array('message_notify_email_body');
+  $context['view_modes'] = array('message_notify_email_body' => TRUE);
   // Check global disable flag.
   if (!variable_get('oa_messages_notifications', TRUE) || empty($context['messages'])) {
     $context['deliver'] = FALSE;


### PR DESCRIPTION
Look at message_digest/plugins/notifier/abstract.inc -> format()
The function expects 
foreach ($view_modes as $view_mode_name => $view_mode)
so an indexed array. Not a flat one. Subsequently, only the index is actually used. This did simply not work, the digest was just rendered in an unknown view_mode, some default state.
