### PR TITLE
Hide non-accessible spaces from settings

### DIFF
--- a/modules/oa_messages/oa_messages.admin.inc
+++ b/modules/oa_messages/oa_messages.admin.inc
@@ -214,6 +214,10 @@ function oa_messages_build_message_notifications_table(&$form_state, $user, $def
     // Build space options.
     foreach ($spaces as $key => $space) {
 
+      if (!node_access('view', $space, $user)) {
+        continue;
+      }
+
       // Set defaults.
       $method_values = NULL;
       $messages_values = NULL;


### PR DESCRIPTION
The user might still be member or subscribed to spaces he has no longer access to.
In our case, they are simply unpublished.
