### PR TITLE
Changed oa_core_get_public_spaces by oa_core_get_top_level_spaces

### DIFF
--- a/includes/oa_core.util.inc
+++ b/includes/oa_core.util.inc
@@ -73,6 +73,32 @@ function oa_core_get_groups_by_user($account = NULL, $group_type = NULL, $includ
 }
 
 /**
+ * Returns all top level spaces
+ * @return array
+ *   An array of Space NIDs.
+ */
+function oa_core_get_top_level_spaces() {
+  $efq = new EntityFieldQuery();
+  $temporary_results = $efq->entityCondition('entity_type', 'node')
+    ->propertyCondition('type', 'oa_space', '=')
+    ->propertyCondition('status', NODE_PUBLISHED, '=')
+    ->fieldCondition('oa_parent_space', 'target_id', NULL, 'IS NOT')
+    ->execute();
+  if (isset($temporary_results['node'])) {
+    //Now get all the other entities, that aren't in the list you just retrieved
+    $efq = new EntityFieldQuery();
+    $results = $efq->entityCondition('entity_type', 'node')
+      ->entityCondition('entity_id', array_keys($temporary_results['node']), 'NOT IN')
+      ->propertyCondition('type', 'oa_space', '=')
+      ->propertyCondition('status', NODE_PUBLISHED, '=')
+      ->execute();
+    $nids = array_keys($results['node']);
+    return $nids;
+  }
+  return array();
+}
+
+/**
  * Returns the current space id context
  * @param  boolean $from_session only use the context stored in $SESSION
  * @return int Space ID

--- a/modules/oa_dashboard/oa_dashboard.module
+++ b/modules/oa_dashboard/oa_dashboard.module
@@ -295,7 +295,7 @@ function template_preprocess_oa_toolbar(&$vars) {
   if (empty($spaces)) {
     // og_get_entity_groups doesn't return anything for anonymous users
     // so return list of all public spaces
-    $spaces = oa_core_get_public_spaces(array(OA_SPACE_TYPE => OA_SPACE_TYPE), NODE_PUBLISHED);
+    $spaces = oa_core_get_top_level_spaces(array(OA_SPACE_TYPE => OA_SPACE_TYPE), NODE_PUBLISHED);
     $menu_title = t('Public Spaces');
   }
   if (empty($spaces)) {


### PR DESCRIPTION
Changed oa_core_get_public_spaces by oa_core_get_top_level_spaces for getting spaces for anonymous user. This is for avoiding to get a big list of spaces if you are an unauthenticated user.
