### PR TITLE
When a Section is moved to a new Space, move all it's content as well.

### DIFF
--- a/includes/oa_core.util.inc
+++ b/includes/oa_core.util.inc
@@ -431,6 +431,28 @@ function oa_core_get_top_parents($bundle, $status = NULL, $include_archived = FA
 }
 
 /**
+ * Get all the content within a particular Section.
+ *
+ * @param int $nid
+ *   The node ID of the Section.
+ *
+ * @return array
+ *   An array of node IDs.
+ */
+function oa_core_get_section_content($nid) {
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'node')
+    ->propertyCondition('status', 1)
+    ->fieldCondition('oa_section_ref', 'target_id', $nid);
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    return array_keys($result['node']);
+  }
+  return array();
+}
+
+/**
  * Determine if a user is a member of a team
  * @param  int $team_id
  * @param  int $user_id

--- a/modules/oa_sections/oa_sections.module
+++ b/modules/oa_sections/oa_sections.module
@@ -36,6 +36,42 @@ function oa_sections_menu() {
 }
 
 /**
+ * Implements hook_node_update().
+ */
+function oa_sections_node_update($node) {
+  // If the Section has been moved to a new Space, then we need to update all
+  // the content inside the Section to also be in the new Space.
+  $original = $node->original;
+  $space_nid = $node->og_group_ref[LANGUAGE_NONE][0]['target_id'];
+  if ($original->og_group_ref[LANGUAGE_NONE][0]['target_id'] != $space_nid) {
+    // Create a batch operation to actually update the child nodes.
+    $child_nids = oa_core_get_section_content($node->nid);   
+    $batch = array(
+      'title' => t('Moving content to new Space'),
+      'operations' => array(),
+    );
+    foreach ($child_nids as $nid) {
+      $batch['operations'][] = array('_oa_sections_batch_change_space_operation', array($nid, $space_nid));
+    }
+    batch_set($batch);
+  }
+}
+
+/**
+ * Batch operation that changes a node's Space.
+ *
+ * @param int $nid
+ *   The NID of the node to update.
+ * @param int $space_nid
+ *   The NID of the Space the node will belong to after changed.
+ */
+function _oa_sections_batch_change_space_operation($nid, $space_nid) {
+  $node = node_load($nid);
+  $node->og_group_ref[LANGUAGE_NONE][0]['target_id'] = $space_nid;
+  node_save($node);
+}
+
+/**
  * Implements hook_og_menu_single_menu_parent().
  */
 function oa_sections_og_menu_single_menu_parent($conf) {

--- a/modules/oa_sections/oa_sections.module
+++ b/modules/oa_sections/oa_sections.module
@@ -44,16 +44,25 @@ function oa_sections_node_update($node) {
   $original = $node->original;
   $space_nid = $node->og_group_ref[LANGUAGE_NONE][0]['target_id'];
   if ($original->og_group_ref[LANGUAGE_NONE][0]['target_id'] != $space_nid) {
-    // Create a batch operation to actually update the child nodes.
     $child_nids = oa_core_get_section_content($node->nid);   
-    $batch = array(
-      'title' => t('Moving content to new Space'),
-      'operations' => array(),
-    );
-    foreach ($child_nids as $nid) {
-      $batch['operations'][] = array('_oa_sections_batch_change_space_operation', array($nid, $space_nid));
+
+    // For 10 nodes or less, we update them inline (per Mike Potter).
+    if (count($child_nids) <= 10) {
+      foreach ($child_nids as $nid) {
+        _oa_sections_batch_change_space_operation($nid, $space_nid);
+      }
     }
-    batch_set($batch);
+    else {
+      // Create a batch operation to actually update the child nodes.
+      $batch = array(
+        'title' => t('Moving content to new Space'),
+        'operations' => array(),
+      );
+      foreach ($child_nids as $nid) {
+        $batch['operations'][] = array('_oa_sections_batch_change_space_operation', array($nid, $space_nid));
+      }
+      batch_set($batch);
+    }
   }
 }
 


### PR DESCRIPTION
Currently, if you change the Space that a Section belongs to (ie. move a Section to a new Space), it's content will continue to belong to the previous Space. This results in all sort of weird behavior - most immediately obvious is that none of the Sections content will show up on it's dashboard or it's new Spaces!

This PR uses the Batch API to update all the Sections child content to belong to the new Space.
